### PR TITLE
Enhance UI using bundled assets

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -8,44 +8,54 @@ struct ContentView: View {
     @State private var selectedEvent: Event?
 
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(events.events) { event in
-                    Button(action: { selectedEvent = event }) {
-                        Text(event.content)
-                    }
-                }
-            }
-            .navigationTitle("Moments")
-            .toolbar {
-                Button("Add") { creating = true }
-            }
-            .sheet(isPresented: $creating) {
-                NavigationView {
-                    VStack {
-                        TextField("Write something", text: $newEventText)
-                            .textFieldStyle(.roundedBorder)
-                            .padding()
-                        Button("Create") {
-                            Task {
-                                if let token = session.token {
-                                    await events.createEvent(token: token, content: newEventText)
-                                    creating = false
-                                    newEventText = ""
-                                }
+        ZStack {
+            Image("day_background")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+
+            NavigationView {
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(events.events) { event in
+                            Button(action: { selectedEvent = event }) {
+                                EventCardView(event: event, background: "card_background1")
                             }
                         }
-                        .padding()
                     }
-                    .navigationTitle("New Moment")
+                    .padding()
                 }
-            }
-            .sheet(item: $selectedEvent) { event in
-                EnergyRoomView(event: event)
-            }
-            .task {
-                await session.ensureSession()
-                await events.loadEvents()
+                .navigationTitle("Moments")
+                .toolbar {
+                    Button("Add") { creating = true }
+                }
+                .sheet(isPresented: $creating) {
+                    NavigationView {
+                        VStack {
+                            TextField("Write something", text: $newEventText)
+                                .textFieldStyle(.roundedBorder)
+                                .padding()
+                            Button("Create") {
+                                Task {
+                                    if let token = session.token {
+                                        await events.createEvent(token: token, content: newEventText)
+                                        creating = false
+                                        newEventText = ""
+                                    }
+                                }
+                            }
+                            .padding()
+                        }
+                        .navigationTitle("New Moment")
+                    }
+                }
+                .sheet(item: $selectedEvent) { event in
+                    EnergyRoomView(event: event)
+                }
+                .task {
+                    await session.ensureSession()
+                    await events.loadEvents()
+                }
             }
         }
     }

--- a/Luma/Luma/EventCardView.swift
+++ b/Luma/Luma/EventCardView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct EventCardView: View {
+    let event: Event
+    let background: String
+
+    var body: some View {
+        ZStack {
+            Image(background)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(height: 120)
+                .clipped()
+                .cornerRadius(16)
+            Text(event.content)
+                .font(.headline)
+                .foregroundColor(.white)
+                .padding()
+                .multilineTextAlignment(.center)
+                .shadow(radius: 4)
+        }
+    }
+}
+
+#Preview {
+    EventCardView(event: Event(id: 1, content: "Hello world", mood: nil, symbol: nil), background: "card_background1")
+}

--- a/Luma/Luma/LumaApp.swift
+++ b/Luma/Luma/LumaApp.swift
@@ -9,9 +9,15 @@ import SwiftUI
 
 @main
 struct LumaApp: App {
+    @State private var showSplash = true
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if showSplash {
+                SplashView(showSplash: $showSplash)
+            } else {
+                ContentView()
+            }
         }
     }
 }

--- a/Luma/Luma/SplashView.swift
+++ b/Luma/Luma/SplashView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct SplashView: View {
+    @Binding var showSplash: Bool
+
+    var body: some View {
+        ZStack {
+            Image("startscreen")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+            VStack {
+                Spacer()
+                Button(action: { showSplash = false }) {
+                    Label("Get Started", systemImage: "sun.max.fill")
+                        .padding()
+                        .background(Color.white.opacity(0.8))
+                        .cornerRadius(12)
+                }
+                .padding(.bottom, 40)
+            }
+        }
+    }
+}
+
+#Preview {
+    SplashView(showSplash: .constant(true))
+}


### PR DESCRIPTION
## Summary
- add splash screen using `startscreen` asset
- show events as cards with `card_background1`
- use `day_background` behind the event list
- switch from splash screen to main app on launch

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68809e9858e083319a5d557f228ba9ef