### PR TITLE
Add offline mock data and event detail view

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -50,7 +50,7 @@ struct ContentView: View {
                     }
                 }
                 .sheet(item: $selectedEvent) { event in
-                    EnergyRoomView(event: event)
+                    EventDetailView(event: event)
                 }
                 .task {
                     await session.ensureSession()

--- a/Luma/Luma/EventDetailView.swift
+++ b/Luma/Luma/EventDetailView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct EventDetailView: View {
+    let event: Event
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack {
+                Spacer()
+                Text(event.content)
+                    .padding()
+                    .multilineTextAlignment(.center)
+                Spacer()
+            }
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+                    .foregroundColor(.black)
+                    .padding(8)
+                    .background(Color.white)
+                    .clipShape(Circle())
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    EventDetailView(event: MockData.events.first!)
+}

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct MockData {
+    static let events: [Event] = [
+        Event(id: 1, content: "A sunny walk in the park", mood: nil, symbol: nil),
+        Event(id: 2, content: "Coffee with friends", mood: nil, symbol: nil),
+        Event(id: 3, content: "Reading a good book", mood: nil, symbol: nil)
+    ]
+}

--- a/Luma/Luma/Services/EventStore.swift
+++ b/Luma/Luma/Services/EventStore.swift
@@ -9,6 +9,8 @@ class EventStore: ObservableObject {
             events = try await APIClient.shared.listEvents()
         } catch {
             print("Failed to load events", error)
+            // Fallback to local mock data when the backend is unavailable
+            events = MockData.events
         }
     }
 

--- a/Luma/Luma/Services/SessionStore.swift
+++ b/Luma/Luma/Services/SessionStore.swift
@@ -17,6 +17,8 @@ class SessionStore: ObservableObject {
             UserDefaults.standard.set(sess.token, forKey: key)
         } catch {
             print("Session creation failed", error)
+            // Use a mock token so the app can run without the backend
+            token = "mock-token"
         }
     }
 }


### PR DESCRIPTION
## Summary
- provide fallback mock events if backend is unreachable
- supply a mock token when session creation fails
- add example events for offline use
- add EventDetailView with close button
- open detail view from the moments list

## Testing
- `xcodebuild test -project Luma/Luma.xcodeproj -scheme Luma -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.5'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a0d807488331b1730211072a576b