### PR TITLE
Add artwork backgrounds and fix nav title

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -9,7 +9,7 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            Image("day_background")
+            Image("day_splash_final2")
                 .resizable()
                 .scaledToFill()
                 .ignoresSafeArea()
@@ -26,6 +26,7 @@ struct ContentView: View {
                     .padding()
                 }
                 .navigationTitle("Moments")
+                .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     Button("Add") { creating = true }
                 }
@@ -50,7 +51,7 @@ struct ContentView: View {
                     }
                 }
                 .sheet(item: $selectedEvent) { event in
-                    EventDetailView(event: event)
+                    EventDetailView(event: event, background: "card_background1")
                 }
                 .task {
                     await session.ensureSession()

--- a/Luma/Luma/EventDetailView.swift
+++ b/Luma/Luma/EventDetailView.swift
@@ -2,15 +2,33 @@ import SwiftUI
 
 struct EventDetailView: View {
     let event: Event
+    let background: String
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
+            Image("day_splash_final2")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+
             VStack {
                 Spacer()
-                Text(event.content)
-                    .padding()
-                    .multilineTextAlignment(.center)
+                ZStack {
+                    Image(background)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(height: 200)
+                        .clipped()
+                        .cornerRadius(16)
+                    Text(event.content)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .padding()
+                        .multilineTextAlignment(.center)
+                        .shadow(radius: 4)
+                }
+                .padding()
                 Spacer()
             }
             Button(action: { dismiss() }) {
@@ -26,5 +44,5 @@ struct EventDetailView: View {
 }
 
 #Preview {
-    EventDetailView(event: MockData.events.first!)
+    EventDetailView(event: MockData.events.first!, background: "card_background1")
 }


### PR DESCRIPTION
## Summary
- display the splash artwork behind the list of moments
- pass a card background image to event details and show it with the general background
- ensure the `Moments` title displays correctly using the inline style

## Testing
- `xcodebuild -list -project Luma.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a7459190833188ea8dd15e173fd5