### PR TITLE
Use dedicated background assets

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -9,7 +9,7 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            Image("day_splash_final2")
+            Image("MainViewBackground")
                 .resizable()
                 .scaledToFill()
                 .ignoresSafeArea()
@@ -19,7 +19,7 @@ struct ContentView: View {
                     LazyVStack(spacing: 16) {
                         ForEach(events.events) { event in
                             Button(action: { selectedEvent = event }) {
-                                EventCardView(event: event, background: "card_background1")
+                                EventCardView(event: event)
                             }
                         }
                     }
@@ -52,7 +52,7 @@ struct ContentView: View {
                     }
                 }
                 .sheet(item: $selectedEvent) { event in
-                    EventDetailView(event: event, background: "card_background1")
+                    EventDetailView(event: event)
                 }
                 .task {
                     await session.ensureSession()

--- a/Luma/Luma/EventCardView.swift
+++ b/Luma/Luma/EventCardView.swift
@@ -2,12 +2,11 @@ import SwiftUI
 
 struct EventCardView: View {
     let event: Event
-    let background: String
     @State private var hovering = false
 
     var body: some View {
         ZStack {
-            Image(background)
+            Image("CardBackground")
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(height: 120)
@@ -27,5 +26,5 @@ struct EventCardView: View {
 }
 
 #Preview {
-    EventCardView(event: Event(id: 1, content: "Hello world", mood: nil, symbol: nil), background: "card_background1")
+    EventCardView(event: Event(id: 1, content: "Hello world", mood: nil, symbol: nil))
 }

--- a/Luma/Luma/EventDetailView.swift
+++ b/Luma/Luma/EventDetailView.swift
@@ -2,12 +2,11 @@ import SwiftUI
 
 struct EventDetailView: View {
     let event: Event
-    let background: String
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         ZStack {
-            Image("day_splash_final2")
+            Image("DetailViewBackground")
                 .resizable()
                 .scaledToFill()
                 .ignoresSafeArea()
@@ -30,7 +29,7 @@ struct EventDetailView: View {
 
                 Spacer()
                 ZStack {
-                    Image(background)
+                    Image("CardBackground")
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(height: 200)
@@ -55,5 +54,5 @@ struct EventDetailView: View {
 }
 
 #Preview {
-    EventDetailView(event: MockData.events.first!, background: "card_background1")
+    EventDetailView(event: MockData.events.first!)
 }


### PR DESCRIPTION
## Summary
- update `ContentView` to use `MainViewBackground` and pass events directly
- set `CardBackground` as the card's default background
- use `DetailViewBackground` for the detail view

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6880b6ed99d08331b21457d774f3acdc