### PR TITLE
Add offline mock mode

### DIFF
--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -1,9 +1,20 @@
 import Foundation
 
-struct MockData {
-    static let events: [Event] = [
+class MockData {
+    static var events: [Event] = [
         Event(id: 1, content: "A sunny walk in the park", mood: nil, symbol: nil),
         Event(id: 2, content: "Coffee with friends", mood: nil, symbol: nil),
         Event(id: 3, content: "Reading a good book", mood: nil, symbol: nil)
     ]
+
+    static func addEvent(content: String) -> Event {
+        let newId = (events.map { $0.id }.max() ?? 0) + 1
+        let event = Event(id: newId, content: content, mood: nil, symbol: nil)
+        events.append(event)
+        return event
+    }
+
+    static func event(id: Int) -> Event? {
+        events.first { $0.id == id }
+    }
 }

--- a/Luma/Luma/Services/APIClient.swift
+++ b/Luma/Luma/Services/APIClient.swift
@@ -2,11 +2,19 @@ import Foundation
 
 class APIClient {
     static let shared = APIClient()
+
+    /// Toggle this flag to use mock data instead of hitting the network.
+    static var useMock = true
+
     private let baseURL = URL(string: "http://localhost:8000/api")!
 
     private init() {}
 
     func createSession() async throws -> Session {
+        if APIClient.useMock {
+            return Session(token: "mock-token")
+        }
+
         var request = URLRequest(url: baseURL.appendingPathComponent("session"))
         request.httpMethod = "POST"
         let (data, _) = try await URLSession.shared.data(for: request)
@@ -14,12 +22,20 @@ class APIClient {
     }
 
     func listEvents() async throws -> [Event] {
+        if APIClient.useMock {
+            return MockData.events
+        }
+
         let url = baseURL.appendingPathComponent("events")
         let (data, _) = try await URLSession.shared.data(from: url)
         return try JSONDecoder().decode([Event].self, from: data)
     }
 
     func createEvent(token: String, event: EventCreate) async throws -> Event {
+        if APIClient.useMock {
+            return MockData.addEvent(content: event.content)
+        }
+
         var components = URLComponents(url: baseURL.appendingPathComponent("events"), resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "session_token", value: token)]
         var request = URLRequest(url: components.url!)
@@ -31,6 +47,10 @@ class APIClient {
     }
 
     func fetchEvent(id: Int) async throws -> Event {
+        if APIClient.useMock {
+            return MockData.event(id: id) ?? MockData.events.first!
+        }
+
         let url = baseURL.appendingPathComponent("events/\(id)")
         let (data, _) = try await URLSession.shared.data(from: url)
         return try JSONDecoder().decode(Event.self, from: data)

--- a/Luma/Luma/Services/PresenceService.swift
+++ b/Luma/Luma/Services/PresenceService.swift
@@ -6,6 +6,13 @@ class PresenceService: ObservableObject {
 
     func connect(eventId: Int) {
         disconnect()
+
+        guard !APIClient.useMock else {
+            // In mock mode just use a fixed presence count
+            count = 1
+            return
+        }
+
         var urlComponents = URLComponents()
         urlComponents.scheme = "ws"
         urlComponents.host = "localhost"

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ Mood definitions (animations, colors, ambient audio) should be loaded from the `
 
 The project ships with placeholder unit and UI tests in `LumaTests` and `LumaUITests`. These can be executed from Xcode or via `xcodebuild` to validate the app once implemented.
 
+## Offline mock mode
+
+By default the app runs without a backend. `APIClient.useMock` is set to `true`,
+causing all API calls and presence updates to return local mock data defined in
+`MockData.swift`. Set this flag to `false` when you want to connect to a real
+server.
+


### PR DESCRIPTION
## Summary
- add dynamic MockData that allows appending events
- allow APIClient to return mock data without hitting the backend
- prevent PresenceService from opening a websocket in mock mode
- document mock mode in the README

## Testing
- `swift --version`
- `xcodebuild -list -project Luma/Luma.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c61538548331be0227d5681956b6