### PR TITLE
Fix card size and menu visibility

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
                         Button("New Moment") { creatingMoment = true }
                     } label: {
                         Image(systemName: "plus")
-                            .foregroundColor(.black)
+                            .foregroundColor(.white)
                     }
                 }
                 .sheet(isPresented: $creatingMoment) {

--- a/Luma/Luma/EventCardView.swift
+++ b/Luma/Luma/EventCardView.swift
@@ -6,7 +6,7 @@ struct EventCardView: View {
 
     var body: some View {
         let cardWidth = UIScreen.main.bounds.width * 0.95
-        let cardHeight = UIScreen.main.bounds.height * 0.3
+        let cardHeight = UIScreen.main.bounds.height * 0.25
 
         return ZStack {
             Image("CardBackground")


### PR DESCRIPTION
## Summary
- adjust card height to 25% of screen height
- change menu button color to white for better visibility

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e16ff9e48331a806245f5bc0225a