### PR TITLE
Implement improved creation flows

### DIFF
--- a/Luma/Luma/CreateMomentView.swift
+++ b/Luma/Luma/CreateMomentView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct CreateMomentView: View {
+    @Binding var text: String
+    var onCreate: (String) -> Void
+    var onDiscard: () -> Void
+
+    var body: some View {
+        VStack {
+            ZStack {
+                Image("OwnMoment")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                TextEditor(text: $text)
+                    .foregroundColor(.clear)
+                    .background(Color.clear)
+                    .padding()
+                Text(text)
+                    .font(.title)
+                    .foregroundColor(.black)
+                    .padding()
+                    .multilineTextAlignment(.center)
+            }
+            .frame(width: UIScreen.main.bounds.width * 0.95,
+                   height: UIScreen.main.bounds.height * 0.6)
+            .cornerRadius(16)
+            .clipped()
+            .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
+            .padding()
+
+            HStack {
+                Button("Discard") { onDiscard() }
+                    .padding()
+                Spacer()
+                Button("Create") { onCreate(text) }
+                    .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    CreateMomentView(text: .constant("")) { _ in } onDiscard: {}
+}

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -9,8 +9,9 @@ struct CreateMoodRoomView: View {
     @State private var recurring = false
     @State private var selectedWeekdays: Set<Int> = []
     @State private var time = Date()
+    @State private var showPreview = false
 
-    private let backgrounds = ["Background 1", "Background 2", "Background 3"]
+    private let backgrounds = ["MoodRoomHappy", "MoodRoomNight", "MoodRoomNature", "MoodRoomSad"]
     private let weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
     var body: some View {
@@ -19,7 +20,7 @@ struct CreateMoodRoomView: View {
                 .font(.headline)
                 .padding()
             ZStack {
-                Image("CardBackground")
+                Image(backgrounds[backgroundIndex])
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                 VStack(spacing: 16) {
@@ -30,8 +31,17 @@ struct CreateMoodRoomView: View {
                     }
                     .pickerStyle(.menu)
 
-                    TextField("Room name", text: $name)
-                        .textFieldStyle(.roundedBorder)
+                    ZStack(alignment: .topLeading) {
+                        if name.isEmpty {
+                            Text("Enter Mood Room name")
+                                .foregroundColor(.gray)
+                                .padding(EdgeInsets(top: 8, leading: 5, bottom: 0, trailing: 0))
+                        }
+                        TextEditor(text: $name)
+                            .background(Color.clear)
+                            .foregroundColor(.primary)
+                            .frame(height: 40)
+                    }
 
                     Toggle("Recurring", isOn: $recurring)
 
@@ -73,11 +83,17 @@ struct CreateMoodRoomView: View {
                 Button("Cancel") { dismiss() }
                     .padding()
                 Spacer()
-                Button("Create") {
-                    onCreate(name)
-                    dismiss()
-                }
+                Button("Preview") { showPreview = true }
                     .padding()
+            }
+            .sheet(isPresented: $showPreview) {
+                MoodRoomView(name: name.isEmpty ? "Unnamed" : name,
+                             background: backgrounds[backgroundIndex],
+                             onCreate: {
+                                 onCreate(name)
+                                 dismiss()
+                             },
+                             onDiscard: { showPreview = false })
             }
         }
     }

--- a/Luma/Luma/EventDetailView.swift
+++ b/Luma/Luma/EventDetailView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct EventDetailView: View {
     let event: Event
+    var isOwnEvent: Bool = false
     @Environment(\.dismiss) private var dismiss
+    @State private var people = 0
 
     var body: some View {
         ZStack {
@@ -41,7 +43,7 @@ struct EventDetailView: View {
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(
-                            Image("CardBackground")
+                            Image(isOwnEvent ? "OwnMoment" : "CardBackground")
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
                         )
@@ -52,11 +54,35 @@ struct EventDetailView: View {
                 .clipped()
                 .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
                 .padding()
-                Text("Swipe down to leave this moment.")
-                    .font(.footnote)
-                    .foregroundColor(.gray)
-                    .padding(.bottom, 20)
+                if isOwnEvent {
+                    Text("There are \(people) people with you in this moment.")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                        .padding(.bottom, 8)
+                } else {
+                    Text("Swipe down to leave this moment.")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                        .padding(.bottom, 20)
+                }
                 Spacer()
+            }
+        }
+        .onAppear {
+            guard isOwnEvent else { return }
+            people = 0
+            incrementPeople()
+        }
+    }
+
+    private func incrementPeople() {
+        guard people < 15 else { return }
+        let delay = Double.random(in: 0...5)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            let addition = Int.random(in: 1...3)
+            people = min(15, people + addition)
+            if people < 15 {
+                incrementPeople()
             }
         }
     }

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -2,7 +2,11 @@ import SwiftUI
 
 struct MoodRoomView: View {
     let name: String
+    var background: String = "MoodRoomHappy"
     @Environment(\.dismiss) private var dismiss
+
+    var onCreate: (() -> Void)? = nil
+    var onDiscard: (() -> Void)? = nil
 
     var body: some View {
         ZStack {
@@ -40,7 +44,7 @@ struct MoodRoomView: View {
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(
-                            Image("CardBackground")
+                            Image(background)
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
                         )
@@ -52,6 +56,14 @@ struct MoodRoomView: View {
                 .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
                 .padding()
 
+                if onCreate != nil || onDiscard != nil {
+                    HStack {
+                        if let onDiscard { Button("Discard") { onDiscard() } }
+                        Spacer()
+                        if let onCreate { Button("Create") { onCreate() } }
+                    }
+                    .padding()
+                }
                 Spacer()
             }
         }


### PR DESCRIPTION
## Summary
- remove "More moments" footer
- add CreateMomentView so text appears directly on the card
- show own moment background and growing participant count
- allow selecting backgrounds and previewing Mood Rooms

## Testing
- `swiftc -emit-sil Luma/Luma/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68813726b4e48331a08ca18ee371e8af