### PR TITLE
Add mood room exploration and preview tweaks

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @State private var myCreatedEventId: Int?
     @State private var showMoodRoom = false
     @State private var createdRoomName = ""
+    @State private var exploringMoodRooms = false
 
     var body: some View {
         NavigationStack {
@@ -36,6 +37,7 @@ struct ContentView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Menu {
+                        Button("Explore Mood Rooms") { exploringMoodRooms = true }
                         Button("New Mood Room") { creatingMoodRoom = true }
                         Button("New Moment") { creatingMoment = true }
                     } label: {
@@ -73,6 +75,9 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showMoodRoom) {
                 MoodRoomView(name: createdRoomName)
+            }
+            .sheet(isPresented: $exploringMoodRooms) {
+                MoodRoomListView()
             }
             .sheet(item: $selectedEvent) { event in
                 EventDetailView(event: event, isOwnEvent: event.id == myCreatedEventId)

--- a/Luma/Luma/CreateMomentView.swift
+++ b/Luma/Luma/CreateMomentView.swift
@@ -14,6 +14,7 @@ struct CreateMomentView: View {
                 TextEditor(text: $text)
                     .foregroundColor(.clear)
                     .background(Color.clear)
+                    .scrollContentBackground(.hidden)
                     .padding()
                 Text(text)
                     .font(.title)

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -23,6 +23,7 @@ struct CreateMoodRoomView: View {
                 Image(backgrounds[backgroundIndex])
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+                let textColor = backgrounds[backgroundIndex] == "MoodRoomNight" ? Color.white : Color.black
                 VStack(spacing: 16) {
                     Picker("Background", selection: $backgroundIndex) {
                         ForEach(0..<backgrounds.count, id: \.self) { idx in
@@ -39,7 +40,7 @@ struct CreateMoodRoomView: View {
                         }
                         TextEditor(text: $name)
                             .background(Color.clear)
-                            .foregroundColor(.primary)
+                            .foregroundColor(textColor)
                             .frame(height: 40)
                     }
 
@@ -70,6 +71,8 @@ struct CreateMoodRoomView: View {
                         }
                     }
                 }
+                .foregroundColor(textColor)
+                .tint(textColor)
                 .padding()
             }
             .frame(width: UIScreen.main.bounds.width * 0.95,

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -7,6 +7,12 @@ class MockData {
         Event(id: 3, content: "Reading a good book", mood: nil, symbol: nil)
     ]
 
+    static var moodRooms: [MoodRoom] = [
+        MoodRoom(name: "Monday Blues", schedule: "Every Monday at 17:30"),
+        MoodRoom(name: "Mindful night routine", schedule: "Daily at 22:00"),
+        MoodRoom(name: "Saturday for Reflection", schedule: "Every Saturday at 10:00")
+    ]
+
     static func addEvent(content: String) -> Event {
         let newId = (events.map { $0.id }.max() ?? 0) + 1
         let event = Event(id: newId, content: content, mood: nil, symbol: nil)

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SwiftUI
+
+struct MoodRoom: Identifiable {
+    let id = UUID()
+    let name: String
+    let schedule: String
+}

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct MoodRoomCardView: View {
+    let room: MoodRoom
+
+    var body: some View {
+        let cardWidth = UIScreen.main.bounds.width * 0.95
+        let cardHeight = UIScreen.main.bounds.height * 0.2
+        ZStack {
+            Image("TintedCardBackground")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: cardWidth, height: cardHeight)
+                .clipped()
+                .cornerRadius(16)
+            VStack {
+                Text(room.name)
+                    .font(.title2)
+                    .foregroundColor(.black)
+                Text(room.schedule)
+                    .font(.caption)
+                    .foregroundColor(.black)
+            }
+            .multilineTextAlignment(.center)
+            .padding()
+        }
+        .frame(width: cardWidth, height: cardHeight)
+        .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
+    }
+}
+
+#Preview {
+    MoodRoomCardView(room: MoodRoom(name: "Test", schedule: "Daily"))
+}

--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct MoodRoomListView: View {
+    @Environment(\.dismiss) private var dismiss
+    let rooms: [MoodRoom] = MockData.moodRooms
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Image("startscreen")
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(rooms) { room in
+                            MoodRoomCardView(room: room)
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical)
+                }
+            }
+            .navigationTitle("Mood Rooms")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(.black)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    MoodRoomListView()
+}

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -7,10 +7,11 @@ struct MoodRoomView: View {
 
     var onCreate: (() -> Void)? = nil
     var onDiscard: (() -> Void)? = nil
+    @State private var duration: Double = 1
 
     var body: some View {
         ZStack {
-            Image("DetailViewBackground")
+            Image(onCreate != nil || onDiscard != nil ? "startscreen" : "DetailViewBackground")
                 .resizable()
                 .scaledToFill()
                 .ignoresSafeArea()
@@ -31,15 +32,17 @@ struct MoodRoomView: View {
                 }
                 .padding()
 
+                let textColor = background == "MoodRoomNight" ? Color.white : Color.black
+
                 Text("Mood room")
                     .font(.headline)
-                    .foregroundColor(Color(.darkGray))
+                    .foregroundColor(textColor)
                     .padding(.bottom, 8)
 
                 ZStack {
                     Text(name)
                         .font(.title)
-                        .foregroundColor(.black)
+                        .foregroundColor(textColor)
                         .padding()
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -57,12 +60,20 @@ struct MoodRoomView: View {
                 .padding()
 
                 if onCreate != nil || onDiscard != nil {
-                    HStack {
-                        if let onDiscard { Button("Discard") { onDiscard() } }
-                        Spacer()
-                        if let onCreate { Button("Create") { onCreate() } }
+                    VStack {
+                        HStack {
+                            Text("Duration: \(Int(duration * 60)) min")
+                            Slider(value: $duration, in: 0.1...3, step: 0.1)
+                        }
+                        .padding(.horizontal)
+
+                        HStack {
+                            if let onDiscard { Button("Discard") { onDiscard() }.foregroundColor(.black) }
+                            Spacer()
+                            if let onCreate { Button("Create") { onCreate() }.foregroundColor(.black) }
+                        }
+                        .padding()
                     }
-                    .padding()
                 }
                 Spacer()
             }


### PR DESCRIPTION
## Summary
- make Moment text box transparent
- ensure color for mood room creation fields depending on background
- allow setting duration when previewing mood rooms
- use startscreen background and black button text in preview
- add mock data and views to explore mood rooms
- hook up explore button in plus menu

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_688144f7579c833187c4f16a01b4231e