### PR TITLE
Update mood room interactions

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @State private var myCreatedEventId: Int?
     @State private var showMoodRoom = false
     @State private var createdRoomName = ""
+    @State private var createdRoomBackground = "MoodRoomHappy"
     @State private var exploringMoodRooms = false
 
     var body: some View {
@@ -68,13 +69,14 @@ struct ContentView: View {
                 }
             }
             .sheet(isPresented: $creatingMoodRoom) {
-                CreateMoodRoomView { name in
+                CreateMoodRoomView { name, background in
                     createdRoomName = name
+                    createdRoomBackground = background
                     showMoodRoom = true
                 }
             }
             .sheet(isPresented: $showMoodRoom) {
-                MoodRoomView(name: createdRoomName)
+                MoodRoomView(name: createdRoomName, background: createdRoomBackground)
             }
             .sheet(isPresented: $exploringMoodRooms) {
                 MoodRoomListView()

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CreateMoodRoomView: View {
     @Environment(\.dismiss) private var dismiss
-    var onCreate: (String) -> Void = { _ in }
+    var onCreate: (String, String) -> Void = { _, _ in }
 
     @State private var name: String = ""
     @State private var backgroundIndex = 0
@@ -32,6 +32,7 @@ struct CreateMoodRoomView: View {
                         }
                     }
                     .pickerStyle(.menu)
+                    .padding(.horizontal)
 
                     ZStack(alignment: .topLeading) {
                         if name.isEmpty {
@@ -68,8 +69,8 @@ struct CreateMoodRoomView: View {
                         }
                     }
 
-                    HStack {
-                        Text("Starting")
+                    VStack(alignment: .leading) {
+                        Text("Start")
                         DatePicker("", selection: $time, displayedComponents: .hourAndMinute)
                             .labelsHidden()
                             .datePickerStyle(.wheel)
@@ -123,8 +124,8 @@ struct CreateMoodRoomView: View {
                     } else {
                         schedule = "Once at \(timeString)"
                     }
-                    MockData.addMoodRoom(name: name.isEmpty ? "Unnamed" : name, schedule: schedule)
-                    onCreate(name)
+                    MockData.addMoodRoom(name: name.isEmpty ? "Unnamed" : name, schedule: schedule, background: backgrounds[backgroundIndex])
+                    onCreate(name, backgrounds[backgroundIndex])
                     dismiss()
                 }
                 .padding()
@@ -133,7 +134,7 @@ struct CreateMoodRoomView: View {
                 MoodRoomView(name: name.isEmpty ? "Unnamed" : name,
                              background: backgrounds[backgroundIndex],
                              onCreate: {
-                                 onCreate(name)
+                                 onCreate(name, backgrounds[backgroundIndex])
                                  dismiss()
                              },
                              onDiscard: { showPreview = false })

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -7,14 +7,20 @@ class MockData {
         Event(id: 3, content: "Reading a good book", mood: nil, symbol: nil)
     ]
 
-    static var moodRooms: [MoodRoom] = [
-        MoodRoom(name: "Monday Blues", schedule: "Every Monday at 17:30"),
-        MoodRoom(name: "Mindful night routine", schedule: "Daily at 22:00"),
-        MoodRoom(name: "Saturday for Reflection", schedule: "Every Saturday at 10:00")
+    static var presetMoodRooms: [MoodRoom] = [
+        MoodRoom(name: "Monday Blues", schedule: "Every Monday at 17:30", background: "MoodRoomSad"),
+        MoodRoom(name: "Mindful night routine", schedule: "Daily at 22:00", background: "MoodRoomNight"),
+        MoodRoom(name: "Saturday for Reflection", schedule: "Every Saturday at 10:00", background: "MoodRoomNature")
     ]
 
-    static func addMoodRoom(name: String, schedule: String) {
-        moodRooms.append(MoodRoom(name: name, schedule: schedule))
+    static var userMoodRooms: [MoodRoom] = []
+
+    static var moodRooms: [MoodRoom] {
+        userMoodRooms + presetMoodRooms
+    }
+
+    static func addMoodRoom(name: String, schedule: String, background: String) {
+        userMoodRooms.insert(MoodRoom(name: name, schedule: schedule, background: background), at: 0)
     }
 
     static func addEvent(content: String) -> Event {

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -1,8 +1,9 @@
 import Foundation
 import SwiftUI
 
-struct MoodRoom: Identifiable {
+struct MoodRoom: Identifiable, Hashable {
     let id = UUID()
     let name: String
     let schedule: String
+    let background: String
 }

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -7,7 +7,7 @@ struct MoodRoomCardView: View {
         let cardWidth = UIScreen.main.bounds.width * 0.95
         let cardHeight = UIScreen.main.bounds.height * 0.2
         ZStack {
-            Image("TintedCardBackground")
+            Image(room.background)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: cardWidth, height: cardHeight)
@@ -30,5 +30,5 @@ struct MoodRoomCardView: View {
 }
 
 #Preview {
-    MoodRoomCardView(room: MoodRoom(name: "Test", schedule: "Daily"))
+    MoodRoomCardView(room: MoodRoom(name: "Test", schedule: "Daily", background: "MoodRoomHappy"))
 }

--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -2,20 +2,28 @@ import SwiftUI
 
 struct MoodRoomListView: View {
     @Environment(\.dismiss) private var dismiss
-    let rooms: [MoodRoom] = MockData.moodRooms
-
     var body: some View {
         NavigationStack {
             ZStack {
-                Image("startscreen")
+                Image("MainViewBackground")
                     .resizable()
                     .scaledToFill()
                     .ignoresSafeArea()
 
                 ScrollView {
                     LazyVStack(spacing: 16) {
-                        ForEach(rooms) { room in
-                            MoodRoomCardView(room: room)
+                        ForEach(MockData.userMoodRooms) { room in
+                            NavigationLink(destination: MoodRoomView(name: room.name, background: room.background)) {
+                                MoodRoomCardView(room: room)
+                            }
+                        }
+                        if !MockData.userMoodRooms.isEmpty {
+                            Divider()
+                        }
+                        ForEach(MockData.presetMoodRooms) { room in
+                            NavigationLink(destination: MoodRoomView(name: room.name, background: room.background)) {
+                                MoodRoomCardView(room: room)
+                            }
                         }
                     }
                     .padding(.horizontal, 8)

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -7,7 +7,6 @@ struct MoodRoomView: View {
 
     var onCreate: (() -> Void)? = nil
     var onDiscard: (() -> Void)? = nil
-    @State private var duration: Double = 1
 
     var body: some View {
         ZStack {
@@ -60,20 +59,12 @@ struct MoodRoomView: View {
                 .padding()
 
                 if onCreate != nil || onDiscard != nil {
-                    VStack {
-                        HStack {
-                            Text("Duration: \(Int(duration * 60)) min")
-                            Slider(value: $duration, in: 0.1...3, step: 0.1)
-                        }
-                        .padding(.horizontal)
-
-                        HStack {
-                            if let onDiscard { Button("Discard") { onDiscard() }.foregroundColor(.black) }
-                            Spacer()
-                            if let onCreate { Button("Create") { onCreate() }.foregroundColor(.black) }
-                        }
-                        .padding()
+                    HStack {
+                        if let onDiscard { Button("Discard") { onDiscard() }.foregroundColor(.black) }
+                        Spacer()
+                        if let onCreate { Button("Create") { onCreate() }.foregroundColor(.black) }
                     }
+                    .padding()
                 }
                 Spacer()
             }


### PR DESCRIPTION
## Summary
- display mood room cards with their chosen backgrounds
- update create mood room view with `Start` text, spacing, and background selection support
- save chosen background for new rooms and list user created rooms first
- remove duration slider from mood room preview
- open mood rooms from the list in a navigation view with main background

## Testing
- `swift-format lint Luma/*.swift` *(fails: many warnings but command executed)*
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_6882877b9e0883318a9113557dc6560c