### PR TITLE
Update mood room behaviour and card visuals

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -74,6 +74,7 @@ struct CreateMoodRoomView: View {
                         DatePicker("", selection: $time, displayedComponents: .hourAndMinute)
                             .labelsHidden()
                             .datePickerStyle(.wheel)
+                            .colorScheme(backgrounds[backgroundIndex] == "MoodRoomNight" ? .dark : .light)
                     }
 
                     HStack {
@@ -94,6 +95,7 @@ struct CreateMoodRoomView: View {
                             }
                         }
                         .pickerStyle(.wheel)
+                        .colorScheme(backgrounds[backgroundIndex] == "MoodRoomNight" ? .dark : .light)
                     }
                 }
                 .foregroundColor(textColor)
@@ -136,11 +138,7 @@ struct CreateMoodRoomView: View {
             .sheet(isPresented: $showPreview) {
                 MoodRoomView(name: name.isEmpty ? "Unnamed" : name,
                              background: backgrounds[backgroundIndex],
-                             onCreate: {
-                                 onCreate(name, backgrounds[backgroundIndex])
-                                 dismiss()
-                             },
-                             onDiscard: { showPreview = false })
+                             isPreview: true)
             }
         }
     }

--- a/Luma/Luma/EventCardView.swift
+++ b/Luma/Luma/EventCardView.swift
@@ -9,7 +9,9 @@ struct EventCardView: View {
         let cardHeight = UIScreen.main.bounds.height * 0.25
 
         return ZStack {
-            AnimatedWavesView()
+            Image("CardBackground")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .frame(width: cardWidth, height: cardHeight)
                 .clipped()
                 .cornerRadius(16)

--- a/Luma/Luma/EventDetailView.swift
+++ b/Luma/Luma/EventDetailView.swift
@@ -41,7 +41,9 @@ struct EventDetailView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                     } else {
-                        AnimatedWavesView()
+                        Image("CardBackground")
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
                     }
                     Text(event.content)
                         .font(.title)

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -8,9 +8,21 @@ class MockData {
     ]
 
     static var presetMoodRooms: [MoodRoom] = [
-        MoodRoom(name: "Monday Blues", schedule: "Every Monday at 17:30", background: "MoodRoomSad", durationMinutes: 30, isActive: true),
-        MoodRoom(name: "Mindful night routine", schedule: "Daily at 22:00", background: "MoodRoomNight", durationMinutes: 30, isActive: true),
-        MoodRoom(name: "Saturday for Reflection", schedule: "Every Saturday at 10:00", background: "MoodRoomNature", durationMinutes: 30, isActive: true)
+        MoodRoom(name: "Monday Blues",
+                 schedule: "Every Monday at 17:30",
+                 background: "MoodRoomSad",
+                 startTime: Date().addingTimeInterval(600),
+                 durationMinutes: 30),
+        MoodRoom(name: "Mindful night routine",
+                 schedule: "Daily at 22:00",
+                 background: "MoodRoomNight",
+                 startTime: Date().addingTimeInterval(900),
+                 durationMinutes: 30),
+        MoodRoom(name: "Saturday for Reflection",
+                 schedule: "Every Saturday at 10:00",
+                 background: "MoodRoomNature",
+                 startTime: Date().addingTimeInterval(1200),
+                 durationMinutes: 30)
     ]
 
     static var userMoodRooms: [MoodRoom] = []
@@ -22,13 +34,12 @@ class MockData {
     static func addMoodRoom(name: String,
                              schedule: String,
                              background: String,
-                             durationMinutes: Int,
-                             isActive: Bool = true) {
+                             durationMinutes: Int) {
         userMoodRooms.insert(MoodRoom(name: name,
                                       schedule: schedule,
                                       background: background,
-                                      durationMinutes: durationMinutes,
-                                      isActive: isActive),
+                                      startTime: Date().addingTimeInterval(600),
+                                      durationMinutes: durationMinutes),
                              at: 0)
     }
 

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -6,6 +6,12 @@ struct MoodRoom: Identifiable, Hashable {
     let name: String
     let schedule: String
     let background: String
+    let startTime: Date
     var durationMinutes: Int
-    var isActive: Bool
+
+    var isJoinable: Bool {
+        let openTime = startTime.addingTimeInterval(-300)
+        let closeTime = startTime.addingTimeInterval(TimeInterval(durationMinutes * 60))
+        return Date() >= openTime && Date() <= closeTime
+    }
 }

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MoodRoomCardView: View {
     let room: MoodRoom
+    var joinable: Bool = true
 
     var body: some View {
         let cardWidth = UIScreen.main.bounds.width * 0.95
@@ -27,9 +28,17 @@ struct MoodRoomCardView: View {
         }
         .frame(width: cardWidth, height: cardHeight)
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
+        .overlay(
+            joinable ? nil : Color.gray.opacity(0.4)
+        )
+        .allowsHitTesting(joinable)
     }
 }
 
 #Preview {
-    MoodRoomCardView(room: MoodRoom(name: "Test", schedule: "Daily", background: "MoodRoomHappy", durationMinutes: 30, isActive: true))
+    MoodRoomCardView(room: MoodRoom(name: "Test",
+                                   schedule: "Daily",
+                                   background: "MoodRoomHappy",
+                                   startTime: Date(),
+                                   durationMinutes: 30))
 }

--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct MoodRoomListView: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var now = Date()
     var body: some View {
+        let _ = now
         NavigationStack {
             ZStack {
                 Image("MainViewBackground")
@@ -12,27 +14,36 @@ struct MoodRoomListView: View {
 
                 ScrollView {
                     LazyVStack(spacing: 16) {
+                        if !MockData.userMoodRooms.isEmpty {
+                            Text("Your mood rooms")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+
                         ForEach(MockData.userMoodRooms) { room in
-                            if room.isActive {
+                            if room.isJoinable {
                                 NavigationLink(destination: MoodRoomView(name: room.name, background: room.background)) {
                                     MoodRoomCardView(room: room)
                                 }
                             } else {
-                                MoodRoomCardView(room: room)
-                                    .opacity(0.6)
+                                MoodRoomCardView(room: room, joinable: false)
                             }
                         }
+
                         if !MockData.userMoodRooms.isEmpty {
                             Divider()
+                            Text("Mood rooms created by others")
+                                .font(.caption)
+                                .foregroundColor(.gray)
                         }
+
                         ForEach(MockData.presetMoodRooms) { room in
-                            if room.isActive {
+                            if room.isJoinable {
                                 NavigationLink(destination: MoodRoomView(name: room.name, background: room.background)) {
                                     MoodRoomCardView(room: room)
                                 }
                             } else {
-                                MoodRoomCardView(room: room)
-                                    .opacity(0.6)
+                                MoodRoomCardView(room: room, joinable: false)
                             }
                         }
                     }
@@ -48,6 +59,9 @@ struct MoodRoomListView: View {
                         .foregroundColor(.black)
                 }
             }
+        }
+        .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { _ in
+            now = Date()
         }
     }
 }

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MoodRoomView: View {
     let name: String
     var background: String = "MoodRoomHappy"
+    var isPreview: Bool = false
     @Environment(\.dismiss) private var dismiss
 
     var onCreate: (() -> Void)? = nil
@@ -65,6 +66,11 @@ struct MoodRoomView: View {
                         if let onCreate { Button("Create") { onCreate() }.foregroundColor(.black) }
                     }
                     .padding()
+                } else if isPreview {
+                    Text("Swipe down to close preview.")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                        .padding(.bottom, 20)
                 }
                 Spacer()
             }
@@ -73,5 +79,5 @@ struct MoodRoomView: View {
 }
 
 #Preview {
-    MoodRoomView(name: "Test Room")
+    MoodRoomView(name: "Test Room", isPreview: true)
 }


### PR DESCRIPTION
## Summary
- use `CardBackground` image for event cards and event details
- display mood rooms with joinability overlay and preview hint
- show time/duration wheels in white on the night background
- add labels in mood room list for user and other rooms
- compute joinable state based on start time

## Testing
- `swiftc -parse Luma/Luma/*.swift`

------
https://chatgpt.com/codex/tasks/task_e_68828f15cd3c8331b0aa2a5fd0dffb14