### PR TITLE
Improve moment and mood room UI

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -7,8 +7,6 @@ struct ContentView: View {
     @State private var creatingMoment = false
     @State private var creatingMoodRoom = false
     @State private var selectedEvent: Event?
-    @State private var myCreatedEventId: Int?
-    @State private var showMoodRoom = false
     @State private var createdRoomName = ""
     @State private var createdRoomBackground = "MoodRoomHappy"
     @State private var exploringMoodRooms = false
@@ -25,7 +23,7 @@ struct ContentView: View {
                     LazyVStack(spacing: 16) {
                         ForEach(events.events) { event in
                             Button(action: { selectedEvent = event }) {
-                                EventCardView(event: event)
+                                EventCardView(event: event, isOwnEvent: events.ownEventIds.contains(event.id))
                             }
                         }
                     }
@@ -58,7 +56,6 @@ struct ContentView: View {
                             if let created = await events.createEvent(token: token, content: text) {
                                 creatingMoment = false
                                 newEventText = ""
-                                myCreatedEventId = created.id
                                 selectedEvent = created
                             }
                         }
@@ -72,17 +69,14 @@ struct ContentView: View {
                 CreateMoodRoomView { name, background in
                     createdRoomName = name
                     createdRoomBackground = background
-                    showMoodRoom = true
+                    exploringMoodRooms = true
                 }
-            }
-            .sheet(isPresented: $showMoodRoom) {
-                MoodRoomView(name: createdRoomName, background: createdRoomBackground)
             }
             .sheet(isPresented: $exploringMoodRooms) {
                 MoodRoomListView()
             }
             .sheet(item: $selectedEvent) { event in
-                EventDetailView(event: event, isOwnEvent: event.id == myCreatedEventId)
+                EventDetailView(event: event, isOwnEvent: events.ownEventIds.contains(event.id))
             }
             .task {
                 await session.ensureSession()

--- a/Luma/Luma/CreateMomentView.swift
+++ b/Luma/Luma/CreateMomentView.swift
@@ -11,11 +11,6 @@ struct CreateMomentView: View {
                 Image("OwnMoment")
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                TextEditor(text: $text)
-                    .foregroundColor(.clear)
-                    .background(Color.clear)
-                    .scrollContentBackground(.hidden)
-                    .padding()
                 Text(text)
                     .font(.title)
                     .foregroundColor(.black)
@@ -28,6 +23,11 @@ struct CreateMomentView: View {
             .clipped()
             .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
             .padding()
+
+            TextEditor(text: $text)
+                .scrollContentBackground(.hidden)
+                .frame(height: 100)
+                .padding([.horizontal])
 
             HStack {
                 Button("Discard") { onDiscard() }

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -33,6 +33,7 @@ struct CreateMoodRoomView: View {
                     }
                     .pickerStyle(.menu)
                     .padding(.horizontal)
+                    .padding(.top, 8)
 
                     ZStack(alignment: .topLeading) {
                         if name.isEmpty {

--- a/Luma/Luma/EventCardView.swift
+++ b/Luma/Luma/EventCardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct EventCardView: View {
     let event: Event
+    var isOwnEvent: Bool = false
     @State private var hovering = false
 
     var body: some View {
@@ -9,7 +10,7 @@ struct EventCardView: View {
         let cardHeight = UIScreen.main.bounds.height * 0.25
 
         return ZStack {
-            Image("CardBackground")
+            Image(isOwnEvent ? "OwnMoment" : "CardBackground")
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: cardWidth, height: cardHeight)
@@ -30,5 +31,5 @@ struct EventCardView: View {
 }
 
 #Preview {
-    EventCardView(event: Event(id: 1, content: "Hello world", mood: nil, symbol: nil))
+    EventCardView(event: Event(id: 1, content: "Hello world", mood: nil, symbol: nil), isOwnEvent: true)
 }

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -29,7 +29,7 @@ struct MoodRoomCardView: View {
         .frame(width: cardWidth, height: cardHeight)
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
         .overlay(
-            joinable ? nil : Color.gray.opacity(0.4)
+            joinable ? nil : Color.gray.opacity(0.65)
         )
         .allowsHitTesting(joinable)
     }

--- a/Luma/Luma/Services/EventStore.swift
+++ b/Luma/Luma/Services/EventStore.swift
@@ -3,6 +3,7 @@ import Foundation
 @MainActor
 class EventStore: ObservableObject {
     @Published var events: [Event] = []
+    @Published var ownEventIds: Set<Int> = []
 
     func loadEvents() async {
         do {
@@ -18,6 +19,7 @@ class EventStore: ObservableObject {
         do {
             let created = try await APIClient.shared.createEvent(token: token, event: EventCreate(content: content, mood: "rain", symbol: "✨"))
             await loadEvents()
+            ownEventIds.insert(created.id)
             return created
         } catch {
             print("Failed to create event", error)


### PR DESCRIPTION
## Summary
- mark created moments as own via EventStore
- highlight own moments with `OwnMoment` background in EventCardView
- show text input below the moment card
- add spacing above mood room background picker
- darken disabled mood room overlay
- show mood room list after creating a new room

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688296288a448331aaaf1b1654e39368