### PR TITLE
Add creation timestamp and fix mood room join window

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -130,6 +130,7 @@ struct CreateMoodRoomView: View {
                     MockData.addMoodRoom(name: name.isEmpty ? "Unnamed" : name,
                                          schedule: schedule,
                                          background: backgrounds[backgroundIndex],
+                                         startTime: time,
                                          durationMinutes: durationMinutes)
                     onCreate(name, backgrounds[backgroundIndex])
                     dismiss()

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -12,16 +12,19 @@ class MockData {
                  schedule: "Every Monday at 17:30",
                  background: "MoodRoomSad",
                  startTime: Date().addingTimeInterval(600),
+                 createdAt: Date(),
                  durationMinutes: 30),
         MoodRoom(name: "Mindful night routine",
                  schedule: "Daily at 22:00",
                  background: "MoodRoomNight",
                  startTime: Date().addingTimeInterval(900),
+                 createdAt: Date(),
                  durationMinutes: 30),
         MoodRoom(name: "Saturday for Reflection",
                  schedule: "Every Saturday at 10:00",
                  background: "MoodRoomNature",
                  startTime: Date().addingTimeInterval(1200),
+                 createdAt: Date(),
                  durationMinutes: 30)
     ]
 
@@ -34,11 +37,13 @@ class MockData {
     static func addMoodRoom(name: String,
                              schedule: String,
                              background: String,
+                             startTime: Date,
                              durationMinutes: Int) {
         userMoodRooms.insert(MoodRoom(name: name,
                                       schedule: schedule,
                                       background: background,
-                                      startTime: Date().addingTimeInterval(600),
+                                      startTime: startTime,
+                                      createdAt: Date(),
                                       durationMinutes: durationMinutes),
                              at: 0)
     }

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -7,11 +7,11 @@ struct MoodRoom: Identifiable, Hashable {
     let schedule: String
     let background: String
     let startTime: Date
+    let createdAt: Date
     var durationMinutes: Int
 
     var isJoinable: Bool {
-        let openTime = startTime.addingTimeInterval(-300)
         let closeTime = startTime.addingTimeInterval(TimeInterval(durationMinutes * 60))
-        return Date() >= openTime && Date() <= closeTime
+        return Date() >= startTime && Date() <= closeTime
     }
 }

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -40,5 +40,6 @@ struct MoodRoomCardView: View {
                                    schedule: "Daily",
                                    background: "MoodRoomHappy",
                                    startTime: Date(),
+                                   createdAt: Date(),
                                    durationMinutes: 30))
 }


### PR DESCRIPTION
## Summary
- add `createdAt` to `MoodRoom`
- pass chosen start time to `addMoodRoom`
- record creation date in preset data
- restrict joinability to start time and duration

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68829afc44cc8331964ca538d59770cf