### PR TITLE
Add user simulation to own mood rooms

### DIFF
--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -22,7 +22,9 @@ struct MoodRoomListView: View {
 
                         ForEach(MockData.userMoodRooms) { room in
                             if room.isJoinable {
-                                NavigationLink(destination: MoodRoomView(name: room.name, background: room.background)) {
+                                NavigationLink(destination: MoodRoomView(name: room.name,
+                                                                       background: room.background,
+                                                                       isOwnRoom: true)) {
                                     MoodRoomCardView(room: room)
                                 }
                             } else {

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -4,7 +4,10 @@ struct MoodRoomView: View {
     let name: String
     var background: String = "MoodRoomHappy"
     var isPreview: Bool = false
+    var isOwnRoom: Bool = false
     @Environment(\.dismiss) private var dismiss
+
+    @State private var people = 0
 
     var onCreate: (() -> Void)? = nil
     var onDiscard: (() -> Void)? = nil
@@ -71,8 +74,35 @@ struct MoodRoomView: View {
                         .font(.footnote)
                         .foregroundColor(.gray)
                         .padding(.bottom, 20)
+                } else if isOwnRoom {
+                    Text("There are \(people) people with you in this room.")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                        .padding(.bottom, 8)
+                } else {
+                    Text("Swipe down to leave this room.")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                        .padding(.bottom, 20)
                 }
                 Spacer()
+            }
+        }
+        .onAppear {
+            guard isOwnRoom else { return }
+            people = 0
+            incrementPeople()
+        }
+    }
+
+    private func incrementPeople() {
+        guard people < 15 else { return }
+        let delay = Double.random(in: 0...5)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            let addition = Int.random(in: 1...3)
+            people = min(15, people + addition)
+            if people < 15 {
+                incrementPeople()
             }
         }
     }


### PR DESCRIPTION
## Summary
- show presence simulation in mood rooms created by the user
- indicate user-owned rooms when navigating from the mood room list

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68829e10d160833197bf4fb7dc9eb68b