### PR TITLE
Use full-screen cover for mood rooms

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -72,7 +72,7 @@ struct ContentView: View {
                     exploringMoodRooms = true
                 }
             }
-            .sheet(isPresented: $exploringMoodRooms) {
+            .fullScreenCover(isPresented: $exploringMoodRooms) {
                 MoodRoomListView()
             }
             .sheet(item: $selectedEvent) { event in


### PR DESCRIPTION
## Summary
- open mood room list as a full screen cover instead of a sheet

## Testing
- `xcodebuild -list` *(fails: xcodebuild not available)*

------
https://chatgpt.com/codex/tasks/task_e_68834a8a06c88331860c80b1229a8a60