### PR TITLE
Improve mood room UI

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -95,7 +95,9 @@ struct EnergyRoomView: View {
         VStack {
             Text(content)
                 .padding()
-            Text("\(presence.count) people are with you in this moment.")
+            Text(presence.count == 1 ?
+                 "There is 1 person with you in this moment." :
+                 "There are \(presence.count) persons with you in this moment.")
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .padding()

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -138,8 +138,12 @@ struct CreateMoodRoomView: View {
                 .padding()
             }
             .sheet(isPresented: $showPreview) {
-                MoodRoomView(name: name.isEmpty ? "Unnamed" : name,
-                             background: backgrounds[backgroundIndex],
+                MoodRoomView(room: MoodRoom(name: name.isEmpty ? "Unnamed" : name,
+                                            schedule: "Once",
+                                            background: backgrounds[backgroundIndex],
+                                            startTime: time,
+                                            createdAt: Date(),
+                                            durationMinutes: durationMinutes),
                              isPreview: true)
             }
         }

--- a/Luma/Luma/EventDetailView.swift
+++ b/Luma/Luma/EventDetailView.swift
@@ -59,7 +59,9 @@ struct EventDetailView: View {
                 .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
                 .padding()
                 if isOwnEvent {
-                    Text("There are \(people) people with you in this moment.")
+                    Text(people == 1 ?
+                         "There is 1 person with you in this moment." :
+                         "There are \(people) persons with you in this moment.")
                         .font(.footnote)
                         .foregroundColor(.gray)
                         .padding(.bottom, 8)

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -10,8 +10,9 @@ struct MoodRoom: Identifiable, Hashable {
     let createdAt: Date
     var durationMinutes: Int
 
+    var closeTime: Date { startTime.addingTimeInterval(TimeInterval(durationMinutes * 60)) }
+
     var isJoinable: Bool {
-        let closeTime = startTime.addingTimeInterval(TimeInterval(durationMinutes * 60))
-        return Date() >= startTime && Date() <= closeTime
+        Date() >= startTime && Date() <= closeTime
     }
 }

--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -22,8 +22,8 @@ struct MoodRoomListView: View {
 
                         ForEach(MockData.userMoodRooms) { room in
                             if room.isJoinable {
-                                NavigationLink(destination: MoodRoomView(name: room.name,
-                                                                       background: room.background,
+                                NavigationLink(destination: MoodRoomView(room: room,
+                                                                       isPreview: false,
                                                                        isOwnRoom: true)) {
                                     MoodRoomCardView(room: room)
                                 }
@@ -41,7 +41,7 @@ struct MoodRoomListView: View {
 
                         ForEach(MockData.presetMoodRooms) { room in
                             if room.isJoinable {
-                                NavigationLink(destination: MoodRoomView(name: room.name, background: room.background)) {
+                                NavigationLink(destination: MoodRoomView(room: room)) {
                                     MoodRoomCardView(room: room)
                                 }
                             } else {


### PR DESCRIPTION
## Summary
- overlay participant count at bottom of mood room card
- allow closing mood room automatically when its time elapses
- rename back button in mood room to **Leave** and hide outside count text
- pluralize "person" and use "persons" across mood room and event views
- update navigation links to new MoodRoomView initializer

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68834f2b4e908331a9b819b92c193cf4