### PR TITLE
Fix mood room display issues

### DIFF
--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -28,9 +28,15 @@ struct MoodRoomCardView: View {
         }
         .frame(width: cardWidth, height: cardHeight)
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
-        .overlay(
-            joinable ? nil : Color.gray.opacity(0.65)
-        )
+        .overlay(alignment: .topTrailing) {
+            if !joinable {
+                let unavailableColor = room.background == "MoodRoomNight" ? Color.white : Color.gray
+                Text("Unavailable at the moment")
+                    .font(.caption2)
+                    .foregroundColor(unavailableColor)
+                    .padding(6)
+            }
+        }
         .allowsHitTesting(joinable)
     }
 }

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -120,6 +120,7 @@ struct MoodRoomView: View {
                 .buttonStyle(.plain)
                 Spacer()
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
         }
     }
@@ -150,7 +151,10 @@ struct MoodRoomView: View {
 
     private var remainingTimeText: String {
         let remaining = room.closeTime.timeIntervalSince(now)
-        guard remaining > 0 else { return "0min left" }
+        guard remaining > 0 else { return "Less than 1 minute left" }
+        if remaining < 60 {
+            return "Less than 1 minute left"
+        }
         let minutes = Int(remaining / 60)
         let hours = minutes / 60
         let mins = minutes % 60


### PR DESCRIPTION
## Summary
- keep the leave chevron within the safe area
- show "Less than 1 minute left" when under a minute remains
- show text instead of grey overlay for unavailable mood rooms

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68835c920ec08331921f343ea7ca8db8