### PR TITLE
Implement mood room editing and UI tweaks

### DIFF
--- a/Luma/Luma/CreateMomentView.swift
+++ b/Luma/Luma/CreateMomentView.swift
@@ -7,6 +7,9 @@ struct CreateMomentView: View {
 
     var body: some View {
         VStack {
+            Text("Create a new moment")
+                .font(.headline)
+                .padding()
             ZStack {
                 Image("OwnMoment")
                     .resizable()

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -48,6 +48,23 @@ class MockData {
                              at: 0)
     }
 
+    static func updateMoodRoom(id: UUID,
+                               name: String,
+                               schedule: String,
+                               background: String,
+                               startTime: Date,
+                               durationMinutes: Int) {
+        if let index = userMoodRooms.firstIndex(where: { $0.id == id }) {
+            userMoodRooms[index] = MoodRoom(id: id,
+                                           name: name,
+                                           schedule: schedule,
+                                           background: background,
+                                           startTime: startTime,
+                                           createdAt: userMoodRooms[index].createdAt,
+                                           durationMinutes: durationMinutes)
+        }
+    }
+
     static func addEvent(content: String) -> Event {
         let newId = (events.map { $0.id }.max() ?? 0) + 1
         let event = Event(id: newId, content: content, mood: nil, symbol: nil)

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -2,12 +2,12 @@ import Foundation
 import SwiftUI
 
 struct MoodRoom: Identifiable, Hashable {
-    let id = UUID()
-    let name: String
-    let schedule: String
-    let background: String
-    let startTime: Date
-    let createdAt: Date
+    var id = UUID()
+    var name: String
+    var schedule: String
+    var background: String
+    var startTime: Date
+    var createdAt: Date
     var durationMinutes: Int
 
     var closeTime: Date { startTime.addingTimeInterval(TimeInterval(durationMinutes * 60)) }

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -30,7 +30,7 @@ struct MoodRoomCardView: View {
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
             if !joinable {
-                let unavailableColor = room.background == "MoodRoomNight" ? Color.white : Color.gray
+                let unavailableColor = room.background == "MoodRoomNight" ? Color.white : Color.black
                 Text("Unavailable at the moment")
                     .font(.caption2)
                     .foregroundColor(unavailableColor)

--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MoodRoomListView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var now = Date()
+    @State private var editingRoom: MoodRoom?
     var body: some View {
         let _ = now
         NavigationStack {
@@ -21,14 +22,24 @@ struct MoodRoomListView: View {
                         }
 
                         ForEach(MockData.userMoodRooms) { room in
-                            if room.isJoinable {
-                                NavigationLink(destination: MoodRoomView(room: room,
-                                                                       isPreview: false,
-                                                                       isOwnRoom: true)) {
-                                    MoodRoomCardView(room: room)
+                            ZStack(alignment: .topLeading) {
+                                if room.isJoinable {
+                                    NavigationLink(destination: MoodRoomView(room: room,
+                                                                           isPreview: false,
+                                                                           isOwnRoom: true)) {
+                                        MoodRoomCardView(room: room)
+                                    }
+                                } else {
+                                    MoodRoomCardView(room: room, joinable: false)
                                 }
-                            } else {
-                                MoodRoomCardView(room: room, joinable: false)
+                                Button(action: { editingRoom = room }) {
+                                    Image(systemName: "pencil")
+                                        .foregroundColor(.black)
+                                        .padding(6)
+                                        .background(Color.white.opacity(0.8))
+                                        .clipShape(Circle())
+                                }
+                                .padding(8)
                             }
                         }
 
@@ -64,6 +75,12 @@ struct MoodRoomListView: View {
         }
         .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { _ in
             now = Date()
+        }
+        .sheet(item: $editingRoom) { room in
+            CreateMoodRoomView(editingRoom: room) { _, _ in } onUpdate: { _ in
+                editingRoom = nil
+                now = Date()
+            }
         }
     }
 }

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -112,10 +112,8 @@ struct MoodRoomView: View {
                         Text("Leave mood room")
                             .font(.callout)
                     }
-                    .foregroundColor(.white)
+                    .foregroundColor(room.background == "MoodRoomNight" ? .white : .black)
                     .padding(12)
-                    .background(Color.black.opacity(0.6))
-                    .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
                 Spacer()

--- a/Luma/Luma/StatsView.swift
+++ b/Luma/Luma/StatsView.swift
@@ -15,6 +15,7 @@ struct StatsView: View {
                     .ignoresSafeArea()
 
                 table
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
             .navigationTitle("Statistics")
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- center stats view content
- label create moment screen with a title
- allow mood rooms to be mutable and update mock data
- support editing mood rooms with a pencil icon on the card
- adjust unavailable text color
- tweak leave-room button styling

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883623bfc0083318384715d0e851542