### PR TITLE
Fix mood room availability logic and UI

### DIFF
--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct MoodRoomCardView: View {
     let room: MoodRoom
-    var joinable: Bool = true
 
     var body: some View {
         let cardWidth = UIScreen.main.bounds.width * 0.95
@@ -29,7 +28,7 @@ struct MoodRoomCardView: View {
         .frame(width: cardWidth, height: cardHeight)
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
-            if !joinable {
+            if !room.isJoinable {
                 let unavailableColor = room.background == "MoodRoomNight" ? Color.white : Color.black
                 Text("Unavailable at the moment")
                     .font(.caption2)
@@ -37,7 +36,7 @@ struct MoodRoomCardView: View {
                     .padding(6)
             }
         }
-        .allowsHitTesting(joinable)
+        .allowsHitTesting(room.isJoinable)
     }
 }
 

--- a/Luma/Luma/MoodRoomListView.swift
+++ b/Luma/Luma/MoodRoomListView.swift
@@ -28,9 +28,11 @@ struct MoodRoomListView: View {
                                                                            isPreview: false,
                                                                            isOwnRoom: true)) {
                                         MoodRoomCardView(room: room)
+                                            .id(room)
                                     }
                                 } else {
-                                    MoodRoomCardView(room: room, joinable: false)
+                                    MoodRoomCardView(room: room)
+                                        .id(room)
                                 }
                                 Button(action: { editingRoom = room }) {
                                     Image(systemName: "pencil")
@@ -54,9 +56,11 @@ struct MoodRoomListView: View {
                             if room.isJoinable {
                                 NavigationLink(destination: MoodRoomView(room: room)) {
                                     MoodRoomCardView(room: room)
+                                        .id(room)
                                 }
                             } else {
-                                MoodRoomCardView(room: room, joinable: false)
+                                MoodRoomCardView(room: room)
+                                    .id(room)
                             }
                         }
                     }

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -105,15 +105,10 @@ struct MoodRoomView: View {
         .safeAreaInset(edge: .top) {
             HStack {
                 Button(action: { dismiss() }) {
-                    HStack {
-                        Image(systemName: "chevron.backward")
-                            .resizable()
-                            .frame(width: 16, height: 16)
-                        Text("Leave mood room")
-                            .font(.callout)
-                    }
-                    .foregroundColor(room.background == "MoodRoomNight" ? .white : .black)
-                    .padding(12)
+                    Image(systemName: "chevron.backward")
+                        .imageScale(.large)
+                        .foregroundColor(room.background == "MoodRoomNight" ? .white : .black)
+                        .padding(12)
                 }
                 .buttonStyle(.plain)
                 Spacer()


### PR DESCRIPTION
## Summary
- show a back chevron inside mood room view
- determine availability inside `MoodRoomCardView`
- ensure mood room cards refresh when a room is edited

## Testing
- `swift -version`
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688365e349248331968da84003011800