### PR TITLE
Fix start screen layout

### DIFF
--- a/Luma/Luma/SplashView.swift
+++ b/Luma/Luma/SplashView.swift
@@ -5,10 +5,12 @@ struct SplashView: View {
 
     var body: some View {
         ZStack {
+            Color.black
+                .ignoresSafeArea()
             Image("startscreen")
                 .resizable()
-                .scaledToFill()
-                .ignoresSafeArea()
+                .scaledToFit()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }


### PR DESCRIPTION
## Summary
- center the splash screen image on launch

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836758d1e8833184ecc31ec217dbfb