### PR TITLE
Fix mood room back button visibility

### DIFF
--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -106,9 +106,12 @@ struct MoodRoomView: View {
             HStack {
                 Button(action: { dismiss() }) {
                     Image(systemName: "chevron.backward")
-                        .imageScale(.large)
-                        .foregroundColor(room.background == "MoodRoomNight" ? .white : .black)
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        .foregroundColor(.white)
                         .padding(12)
+                        .background(Color.black.opacity(0.6))
+                        .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
                 Spacer()


### PR DESCRIPTION
## Summary
- ensure the MoodRoom back button stands out by adding a dark circle background

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688367d199a083318571e145a1f2af4c