### PR TITLE
Fix back button and mood room availability

### DIFF
--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -13,6 +13,38 @@ struct MoodRoom: Identifiable, Hashable {
     var closeTime: Date { startTime.addingTimeInterval(TimeInterval(durationMinutes * 60)) }
 
     var isJoinable: Bool {
-        Date() >= startTime && Date() <= closeTime
+        let now = Date()
+        let cal = Calendar.current
+
+        // Once-off rooms use the exact start and close times
+        if schedule.lowercased().hasPrefix("once") {
+            return now >= startTime && now <= closeTime
+        }
+
+        // Check weekday for recurring schedules like "Every Mon, Tue" or "Daily"
+        if schedule.lowercased().hasPrefix("every ") {
+            if let range = schedule.range(of: " at ") {
+                let daysPart = schedule[schedule.index(schedule.startIndex, offsetBy: 6)..<range.lowerBound]
+                let dayTokens = daysPart.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+                if !dayTokens.isEmpty {
+                    let idx = cal.component(.weekday, from: now) - 1 // 0 = Sunday
+                    let todayFull = cal.weekdaySymbols[idx].lowercased()
+                    let todayShort = String(todayFull.prefix(3))
+                    let matches = dayTokens.contains(where: { token in
+                        token.hasPrefix(todayFull) || token.hasPrefix(todayShort)
+                    })
+                    if !matches { return false }
+                }
+            }
+        }
+
+        // Daily schedules and matching weekdays use today's time components
+        let comps = cal.dateComponents([.hour, .minute], from: startTime)
+        guard let startToday = cal.date(bySettingHour: comps.hour ?? 0,
+                                        minute: comps.minute ?? 0,
+                                        second: 0,
+                                        of: now) else { return false }
+        let endToday = startToday.addingTimeInterval(TimeInterval(durationMinutes * 60))
+        return now >= startToday && now <= endToday
     }
 }

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -98,26 +98,15 @@ struct MoodRoomView: View {
             stats.endMoodRoom()
         }
         .interactiveDismissDisabled(!isPreview)
-        .navigationBarBackButtonHidden(true)
         .onReceive(timer) { _ in
             now = Date()
         }
-        .safeAreaInset(edge: .top) {
-            HStack {
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: { dismiss() }) {
                     Image(systemName: "chevron.backward")
-                        .resizable()
-                        .frame(width: 16, height: 16)
-                        .foregroundColor(.white)
-                        .padding(12)
-                        .background(Color.black.opacity(0.6))
-                        .clipShape(Circle())
                 }
-                .buttonStyle(.plain)
-                Spacer()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
         }
     }
 


### PR DESCRIPTION
## Summary
- show a navigation bar back button in `MoodRoomView`
- check the weekday when determining if a mood room is joinable

## Testing
- `swiftc /tmp/test.swift`

------
https://chatgpt.com/codex/tasks/task_e_68836c71cecc833180bc8a0f47be0928