### PR TITLE
Add text color customization for mood rooms

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -15,6 +15,7 @@ struct CreateMoodRoomView: View {
     @State private var durationMinutes = 15
     @State private var showPreview = false
     @State private var confirmDelete = false
+    @State private var textColor: Color = .black
 
     private static let backgrounds = ["MoodRoomHappy", "MoodRoomNight", "MoodRoomNature", "MoodRoomSad"]
     private static let weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -34,6 +35,7 @@ struct CreateMoodRoomView: View {
         if let room = editingRoom {
             _name = State(initialValue: room.name)
             _backgroundIndex = State(initialValue: Self.backgrounds.firstIndex(of: room.background) ?? 0)
+            _textColor = State(initialValue: room.textColor)
             _time = State(initialValue: room.startTime)
             _durationMinutes = State(initialValue: room.durationMinutes)
 
@@ -54,6 +56,9 @@ struct CreateMoodRoomView: View {
             } else {
                 _recurring = State(initialValue: false)
             }
+        } else {
+            let defaultColor: Color = Self.backgrounds[0] == "MoodRoomNight" ? .white : .black
+            _textColor = State(initialValue: defaultColor)
         }
     }
 
@@ -66,7 +71,6 @@ struct CreateMoodRoomView: View {
                 Image(backgrounds[backgroundIndex])
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                let textColor = backgrounds[backgroundIndex] == "MoodRoomNight" ? Color.white : Color.black
                 VStack(spacing: 16) {
                     Picker("Background", selection: $backgroundIndex) {
                         ForEach(0..<backgrounds.count, id: \.self) { idx in
@@ -76,6 +80,9 @@ struct CreateMoodRoomView: View {
                     .pickerStyle(.menu)
                     .padding(.horizontal)
                     .padding(.top, 8)
+
+                    ColorPicker("Text Color", selection: $textColor)
+                        .padding(.horizontal)
 
                     ZStack(alignment: .topLeading) {
                         if name.isEmpty {
@@ -179,6 +186,7 @@ struct CreateMoodRoomView: View {
                                                name: name.isEmpty ? "Unnamed" : name,
                                                schedule: schedule,
                                                background: backgrounds[backgroundIndex],
+                                               textColor: textColor,
                                                startTime: time,
                                                durationMinutes: durationMinutes)
                         onUpdate(editing)
@@ -186,6 +194,7 @@ struct CreateMoodRoomView: View {
                         MockData.addMoodRoom(name: name.isEmpty ? "Unnamed" : name,
                                              schedule: schedule,
                                              background: backgrounds[backgroundIndex],
+                                             textColor: textColor,
                                              startTime: time,
                                              durationMinutes: durationMinutes)
                         onCreate(name, backgrounds[backgroundIndex])
@@ -198,6 +207,7 @@ struct CreateMoodRoomView: View {
                 MoodRoomView(room: MoodRoom(name: name.isEmpty ? "Unnamed" : name,
                                             schedule: "Once",
                                             background: backgrounds[backgroundIndex],
+                                            textColor: textColor,
                                             startTime: time,
                                             createdAt: Date(),
                                             durationMinutes: durationMinutes),

--- a/Luma/Luma/MockData.swift
+++ b/Luma/Luma/MockData.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 class MockData {
     static var events: [Event] = [
@@ -11,18 +12,21 @@ class MockData {
         MoodRoom(name: "Monday Blues",
                  schedule: "Every Monday at 17:30",
                  background: "MoodRoomSad",
+                 textColor: .black,
                  startTime: Date().addingTimeInterval(600),
                  createdAt: Date(),
                  durationMinutes: 30),
         MoodRoom(name: "Mindful night routine",
                  schedule: "Daily at 22:00",
                  background: "MoodRoomNight",
+                 textColor: .white,
                  startTime: Date().addingTimeInterval(900),
                  createdAt: Date(),
                  durationMinutes: 30),
         MoodRoom(name: "Saturday for Reflection",
                  schedule: "Every Saturday at 10:00",
                  background: "MoodRoomNature",
+                 textColor: .black,
                  startTime: Date().addingTimeInterval(1200),
                  createdAt: Date(),
                  durationMinutes: 30)
@@ -37,11 +41,13 @@ class MockData {
     static func addMoodRoom(name: String,
                              schedule: String,
                              background: String,
+                             textColor: Color = .black,
                              startTime: Date,
                              durationMinutes: Int) {
         userMoodRooms.insert(MoodRoom(name: name,
                                       schedule: schedule,
                                       background: background,
+                                     textColor: textColor,
                                       startTime: startTime,
                                       createdAt: Date(),
                                       durationMinutes: durationMinutes),
@@ -52,6 +58,7 @@ class MockData {
                                name: String,
                                schedule: String,
                                background: String,
+                               textColor: Color = .black,
                                startTime: Date,
                                durationMinutes: Int) {
         if let index = userMoodRooms.firstIndex(where: { $0.id == id }) {
@@ -59,6 +66,7 @@ class MockData {
                                            name: name,
                                            schedule: schedule,
                                            background: background,
+                                           textColor: textColor,
                                            startTime: startTime,
                                            createdAt: userMoodRooms[index].createdAt,
                                            durationMinutes: durationMinutes)

--- a/Luma/Luma/MoodRoom.swift
+++ b/Luma/Luma/MoodRoom.swift
@@ -6,6 +6,7 @@ struct MoodRoom: Identifiable, Hashable {
     var name: String
     var schedule: String
     var background: String
+    var textColor: Color = .black
     var startTime: Date
     var createdAt: Date
     var durationMinutes: Int

--- a/Luma/Luma/MoodRoomCardView.swift
+++ b/Luma/Luma/MoodRoomCardView.swift
@@ -14,7 +14,7 @@ struct MoodRoomCardView: View {
                 .clipped()
                 .cornerRadius(16)
             VStack {
-                let textColor = room.background == "MoodRoomNight" ? Color.white : Color.black
+                let textColor = room.textColor
                 Text(room.name)
                     .font(.title2)
                     .foregroundColor(textColor)
@@ -29,10 +29,9 @@ struct MoodRoomCardView: View {
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
             if !room.isJoinable {
-                let unavailableColor = room.background == "MoodRoomNight" ? Color.white : Color.black
                 Text("Unavailable at the moment")
                     .font(.caption2)
-                    .foregroundColor(unavailableColor)
+                    .foregroundColor(room.textColor)
                     .padding(6)
             }
         }
@@ -44,6 +43,7 @@ struct MoodRoomCardView: View {
     MoodRoomCardView(room: MoodRoom(name: "Test",
                                    schedule: "Daily",
                                    background: "MoodRoomHappy",
+                                   textColor: .black,
                                    startTime: Date(),
                                    createdAt: Date(),
                                    durationMinutes: 30))

--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -24,7 +24,7 @@ struct MoodRoomView: View {
 
             VStack(spacing: 0) {
 
-                let textColor = room.background == "MoodRoomNight" ? Color.white : Color.black
+                let textColor = room.textColor
 
                 Text("Mood room")
                     .font(.headline)
@@ -152,6 +152,7 @@ struct MoodRoomView: View {
     MoodRoomView(room: MoodRoom(name: "Test Room",
                                 schedule: "Once",
                                 background: "MoodRoomHappy",
+                                textColor: .black,
                                 startTime: Date(),
                                 createdAt: Date(),
                                 durationMinutes: 15),


### PR DESCRIPTION
## Summary
- allow MoodRoom to store a text color
- pick a text color when creating or editing a mood room
- propagate text color to room previews and cards

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688376a901cc8331b5b1ef1853d3670e