### PR TITLE
Fix mood room colors and center splash image

### DIFF
--- a/Luma/Luma/MoodRoomView.swift
+++ b/Luma/Luma/MoodRoomView.swift
@@ -28,10 +28,10 @@ struct MoodRoomView: View {
 
                 Text("Mood room")
                     .font(.headline)
-                    .foregroundColor(textColor)
+                    .foregroundColor(.black)
                 Text("\(room.schedule) | \(remainingTimeText)")
                     .font(.footnote)
-                    .foregroundColor(textColor)
+                    .foregroundColor(.black)
                     .padding(.bottom, 8)
 
                 Spacer()
@@ -56,7 +56,7 @@ struct MoodRoomView: View {
                              "There is 1 person with you in this mood room." :
                              "There are \(people) persons with you in this mood room.")
                             .font(.footnote)
-                            .foregroundColor(textColor)
+                            .foregroundColor(.black)
                             .padding(8)
                     }
                 }

--- a/Luma/Luma/SplashView.swift
+++ b/Luma/Luma/SplashView.swift
@@ -7,14 +7,13 @@ struct SplashView: View {
         ZStack {
             Color.black
                 .ignoresSafeArea()
-            GeometryReader { proxy in
-                Image("startscreen")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: proxy.size.height)
-                    .frame(maxWidth: .infinity, alignment: .center)
-            }
-            .ignoresSafeArea()
+
+            Image("startscreen")
+                .resizable()
+                .scaledToFit()
+                .frame(maxHeight: .infinity)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .ignoresSafeArea()
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep mood room header and people count text black
- only apply custom text color to room name in the center
- center splash screen image and fill vertically

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68837e0e55948331b179938186267666