### PR TITLE
Fix StatsView width issue

### DIFF
--- a/Luma/Luma/ContentView.swift
+++ b/Luma/Luma/ContentView.swift
@@ -80,7 +80,7 @@ struct ContentView: View {
             .fullScreenCover(isPresented: $exploringMoodRooms) {
                 MoodRoomListView()
             }
-            .sheet(isPresented: $showStats) {
+            .fullScreenCover(isPresented: $showStats) {
                 StatsView()
                     .environmentObject(stats)
             }


### PR DESCRIPTION
## Summary
- switch stats modal to a full-screen presentation

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838bc04c2483318e8ea9b3e52b61f4