### PR TITLE
Add character count for moment and mood room creation

### DIFF
--- a/Luma/Luma/CreateMomentView.swift
+++ b/Luma/Luma/CreateMomentView.swift
@@ -50,6 +50,14 @@ struct CreateMomentView: View {
             .padding([.horizontal])
 
             HStack {
+                Spacer()
+                Text("\(maxLength - text.count) characters left")
+                    .font(.caption2)
+                    .foregroundColor(Color(.darkGray))
+            }
+            .padding(.horizontal)
+
+            HStack {
                 Button("Discard") { onDiscard() }
                     .padding()
                 Spacer()

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -102,6 +102,14 @@ struct CreateMoodRoomView: View {
                             .frame(height: 40)
                     }
 
+                    HStack {
+                        Spacer()
+                        Text("\(maxNameLength - name.count) characters left")
+                            .font(.caption2)
+                            .foregroundColor(Color(.darkGray))
+                    }
+                    .padding(.trailing)
+
                     Toggle("Recurring", isOn: $recurring)
 
                     if recurring {


### PR DESCRIPTION
## Summary
- show how many characters remain when creating a moment
- show remaining characters when entering a mood room name

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Luma/Luma.xcodeproj -scheme Luma -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838cc8cfb083318054205b71b4db64