### PR TITLE
Avoid spurious launch metric errors

### DIFF
--- a/Luma/LumaUITests/LumaUITests.swift
+++ b/Luma/LumaUITests/LumaUITests.swift
@@ -33,9 +33,15 @@ final class LumaUITests: XCTestCase {
 
     @MainActor
     func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+        let app = XCUIApplication()
+        if ProcessInfo.processInfo.environment["ENABLE_LAUNCH_METRICS"] == "1" {
+            // Only gather launch metrics when explicitly enabled. This avoids
+            // spurious simulator errors like missing eligibility plists.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                app.launch()
+            }
+        } else {
+            app.launch()
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Mood definitions (animations, colors, ambient audio) should be loaded from the `
 
 The project ships with placeholder unit and UI tests in `LumaTests` and `LumaUITests`. These can be executed from Xcode or via `xcodebuild` to validate the app once implemented.
 
+### Launch performance metrics
+
+UI tests normally measure launch performance with `XCTApplicationLaunchMetric`. Some simulator environments lack the system files needed for these metrics and emit errors like `load_eligibility_plist` during test runs. Metrics collection is therefore disabled by default. Set the environment variable `ENABLE_LAUNCH_METRICS=1` when running tests if you want to record launch metrics.
+
 ## Offline mock mode
 
 By default the app runs without a backend. `APIClient.useMock` is set to `true`,


### PR DESCRIPTION
## Summary
- gate the XCTApplicationLaunchMetric run behind `ENABLE_LAUNCH_METRICS`
- document the new environment variable in the README

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838eac841c83319c41c09bc71f8588