### PR TITLE
Fix onChange deprecation warnings

### DIFF
--- a/Luma/Luma/CreateMomentView.swift
+++ b/Luma/Luma/CreateMomentView.swift
@@ -35,7 +35,7 @@ struct CreateMomentView: View {
                         .padding(EdgeInsets(top: 8, leading: 5, bottom: 0, trailing: 0))
                 }
                 TextEditor(text: $text)
-                    .onChange(of: text) { newValue in
+                    .onChange(of: text) { _, newValue in
                         if newValue.count > maxLength {
                             text = String(newValue.prefix(maxLength))
                         }

--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -92,7 +92,7 @@ struct CreateMoodRoomView: View {
                                 .padding(EdgeInsets(top: 8, leading: 5, bottom: 0, trailing: 0))
                         }
                         TextEditor(text: $name)
-                            .onChange(of: name) { newValue in
+                            .onChange(of: name) { _, newValue in
                                 if newValue.count > maxNameLength {
                                     name = String(newValue.prefix(maxNameLength))
                                 }


### PR DESCRIPTION
## Summary
- update `.onChange` calls to use new two-parameter closure

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68838fddc0cc83318f1c5149d97ac51b