### PR TITLE
Add time-based stats chart

### DIFF
--- a/Luma/Luma/Services/StatsStore.swift
+++ b/Luma/Luma/Services/StatsStore.swift
@@ -7,16 +7,26 @@ class StatsStore: ObservableObject {
     @Published var timeInMoodRooms: [String: TimeInterval]
     @Published var momentsCreated: Int
     @Published var moodRoomsCreated: Int
+    @Published var dailyMoments: [String: TimeInterval]
+    @Published var dailyMoodRooms: [String: TimeInterval]
 
     private var momentStart: Date?
     private var moodStart: Date?
     private var currentMoodKey: String?
+    private static let dayFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.calendar = Calendar(identifier: .iso8601)
+        df.dateFormat = "yyyy-MM-dd"
+        return df
+    }()
 
     init() {
         self.timeInMoments = UserDefaults.standard.double(forKey: "timeInMoments")
         self.timeInMoodRooms = (UserDefaults.standard.dictionary(forKey: "timeInMoodRooms") as? [String: TimeInterval]) ?? [:]
         self.momentsCreated = UserDefaults.standard.integer(forKey: "momentsCreated")
         self.moodRoomsCreated = UserDefaults.standard.integer(forKey: "moodRoomsCreated")
+        self.dailyMoments = (UserDefaults.standard.dictionary(forKey: "dailyMoments") as? [String: TimeInterval]) ?? [:]
+        self.dailyMoodRooms = (UserDefaults.standard.dictionary(forKey: "dailyMoodRooms") as? [String: TimeInterval]) ?? [:]
     }
 
     func startMoment() {
@@ -28,6 +38,11 @@ class StatsStore: ObservableObject {
         let delta = Date().timeIntervalSince(start)
         timeInMoments += delta
         UserDefaults.standard.set(timeInMoments, forKey: "timeInMoments")
+        let key = Self.dayFormatter.string(from: start)
+        var dict = dailyMoments
+        dict[key, default: 0] += delta
+        dailyMoments = dict
+        UserDefaults.standard.set(dict, forKey: "dailyMoments")
         momentStart = nil
     }
 
@@ -44,6 +59,11 @@ class StatsStore: ObservableObject {
         dict[key, default: 0] += delta
         timeInMoodRooms = dict
         UserDefaults.standard.set(dict, forKey: "timeInMoodRooms")
+        let dayKey = Self.dayFormatter.string(from: start)
+        var moodDict = dailyMoodRooms
+        moodDict[dayKey, default: 0] += delta
+        dailyMoodRooms = moodDict
+        UserDefaults.standard.set(moodDict, forKey: "dailyMoodRooms")
         moodStart = nil
         currentMoodKey = nil
     }


### PR DESCRIPTION
## Summary
- track daily usage stats in `StatsStore`
- overhaul `StatsView` with a bar chart and segment control

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68839232b31c8331b299335bf700649e