### PR TITLE
Fix StatsView formatter visibility and provide sample data

### DIFF
--- a/Luma/Luma/Services/StatsStore.swift
+++ b/Luma/Luma/Services/StatsStore.swift
@@ -13,7 +13,7 @@ class StatsStore: ObservableObject {
     private var momentStart: Date?
     private var moodStart: Date?
     private var currentMoodKey: String?
-    private static let dayFormatter: DateFormatter = {
+    static let dayFormatter: DateFormatter = {
         let df = DateFormatter()
         df.calendar = Calendar(identifier: .iso8601)
         df.dateFormat = "yyyy-MM-dd"
@@ -76,5 +76,36 @@ class StatsStore: ObservableObject {
     func recordMoodRoomCreated() {
         moodRoomsCreated += 1
         UserDefaults.standard.set(moodRoomsCreated, forKey: "moodRoomsCreated")
+    }
+}
+
+extension StatsStore {
+    /// Returns a store populated with sample data for previews.
+    static var sample: StatsStore {
+        let store = StatsStore()
+
+        store.timeInMoments = 60 * 45
+        store.timeInMoodRooms = [
+            "MoodRoomSad-recurring": 60 * 30,
+            "MoodRoomNight-recurring": 60 * 60
+        ]
+
+        store.momentsCreated = 5
+        store.moodRoomsCreated = 3
+
+        let today = Date()
+        var moments: [String: TimeInterval] = [:]
+        var moods: [String: TimeInterval] = [:]
+        for offset in -6...0 {
+            if let date = Calendar.current.date(byAdding: .day, value: offset, to: today) {
+                let key = dayFormatter.string(from: date)
+                moments[key] = Double.random(in: 300...1800)
+                moods[key] = Double.random(in: 120...900)
+            }
+        }
+        store.dailyMoments = moments
+        store.dailyMoodRooms = moods
+
+        return store
     }
 }

--- a/Luma/Luma/StatsView.swift
+++ b/Luma/Luma/StatsView.swift
@@ -154,6 +154,6 @@ struct StatsView: View {
 
 struct StatsView_Previews: PreviewProvider {
     static var previews: some View {
-        StatsView().environmentObject(StatsStore())
+        StatsView().environmentObject(StatsStore.sample)
     }
 }


### PR DESCRIPTION
## Summary
- expose `dayFormatter` so `StatsView` can use it
- supply a static `sample` store for previews
- show sample statistics in `StatsView_Previews`

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688393d4031483319c1425950bd99da8