### PR TITLE
Fix TimeInterval literals in StatsStore sample

### DIFF
--- a/Luma/Luma/Services/StatsStore.swift
+++ b/Luma/Luma/Services/StatsStore.swift
@@ -86,8 +86,8 @@ extension StatsStore {
 
         store.timeInMoments = 60 * 45
         store.timeInMoodRooms = [
-            "MoodRoomSad-recurring": 60 * 30,
-            "MoodRoomNight-recurring": 60 * 60
+            "MoodRoomSad-recurring": TimeInterval(60 * 30),
+            "MoodRoomNight-recurring": TimeInterval(60 * 60)
         ]
 
         store.momentsCreated = 5


### PR DESCRIPTION
## Summary
- use `TimeInterval` constructor when populating `timeInMoodRooms`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68839503de1c8331880c1e289210a69b