### PR TITLE
Fix Stats view layout and add year filtering

### DIFF
--- a/Luma/Luma/LumaApp.swift
+++ b/Luma/Luma/LumaApp.swift
@@ -16,5 +16,6 @@ struct LumaApp: App {
             ContentView()
                 .environmentObject(stats)
         }
+        .supportedOrientations(.portrait)
     }
 }


### PR DESCRIPTION
## Summary
- lock the app to portrait orientation
- clean up Stats view layout
- add year picker and filter for statistics chart
- show time spent in moments vs mood rooms in a chart

## Testing
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_6883969a7f94833199aa5665af35d051