### PR TITLE
Fix orientation modifier error

### DIFF
--- a/Luma/Luma/LumaApp.swift
+++ b/Luma/Luma/LumaApp.swift
@@ -16,6 +16,6 @@ struct LumaApp: App {
             ContentView()
                 .environmentObject(stats)
         }
-        .supportedOrientations(.portrait)
+        .supportedInterfaceOrientations(.portrait)
     }
 }


### PR DESCRIPTION
## Summary
- use `supportedInterfaceOrientations` instead of unsupported modifier

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883986e88dc8331a26b43d1558db031