### PR TITLE
Fix StatsView safe-area layout and conditional chart rendering

### DIFF
--- a/Luma/Luma/StatsView.swift
+++ b/Luma/Luma/StatsView.swift
@@ -25,7 +25,7 @@ struct StatsView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
+            ZStack(alignment: .top) {
                 Image("DetailViewBackground")
                     .resizable()
                     .scaledToFill()
@@ -46,14 +46,21 @@ struct StatsView: View {
                     }
                     .pickerStyle(.menu)
                     .padding(.horizontal)
-                    chart
-                        .frame(height: 220)
-                        .animation(.default, value: period)
-                        .animation(.default, value: selectedYear)
+                    let _ = print("aggregatedData.count = \(aggregatedData.count)")
+                    if !aggregatedData.isEmpty {
+                        chart
+                            .frame(height: 220)
+                            .animation(.default, value: period)
+                            .animation(.default, value: selectedYear)
+                    } else {
+                        Text("No data available")
+                            .frame(height: 220)
+                    }
                     summary
                 }
                 .frame(maxWidth: .infinity)
                 .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
             .navigationTitle("Statistics")
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- ensure content is aligned at the top of the safe area
- expand `VStack` to fill the view and respect safe areas
- print the number of aggregated entries for debugging
- show the chart only when data exists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839e19920c833199a061e496eb97a4