### PR TITLE
Fix StatsView frame call

### DIFF
--- a/Luma/Luma/StatsView.swift
+++ b/Luma/Luma/StatsView.swift
@@ -69,7 +69,8 @@ struct StatsView: View {
                         .frame(maxWidth: .infinity, alignment: .center)
                         .padding(.horizontal, 16)
                 }
-                .frame(width: width, maxHeight: .infinity, alignment: .top)
+                .frame(width: width, alignment: .top)
+                .frame(maxHeight: .infinity, alignment: .top)
                 .padding()
                 .background(
                     Image("DetailViewBackground")


### PR DESCRIPTION
## Summary
- fix invalid .frame modifier usage

## Testing
- `swiftc Luma/Luma/StatsView.swift -o /tmp/StatsView.o` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6883ac69038483318bac3662a0a4befc