### PR TITLE
Extend sample statistics data

### DIFF
--- a/Luma/Luma/Services/StatsStore.swift
+++ b/Luma/Luma/Services/StatsStore.swift
@@ -96,7 +96,7 @@ extension StatsStore {
         let today = Date()
         var moments: [String: TimeInterval] = [:]
         var moods: [String: TimeInterval] = [:]
-        for offset in -6...0 {
+        for offset in stride(from: -59, through: 0, by: 1) {
             if let date = Calendar.current.date(byAdding: .day, value: offset, to: today) {
                 let key = dayFormatter.string(from: date)
                 moments[key] = Double.random(in: 300...1800)


### PR DESCRIPTION
## Summary
- generate sample statistics for the last 60 days instead of only a week

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883b56759c08331a8e5fe7c9a051be2