### PR TITLE
Improve stats chart legend and year picker

### DIFF
--- a/Luma/Luma/Services/StatsStore.swift
+++ b/Luma/Luma/Services/StatsStore.swift
@@ -31,7 +31,7 @@ class StatsStore: ObservableObject {
 
         // Provide example data when there is nothing stored yet
         if dailyMoments.isEmpty && dailyMoodRooms.isEmpty {
-            (dailyMoments, dailyMoodRooms) = Self.generateLastTwoMonths()
+            (dailyMoments, dailyMoodRooms) = Self.generateLastThreeMonths()
         }
     }
 
@@ -99,17 +99,17 @@ extension StatsStore {
         store.momentsCreated = 5
         store.moodRoomsCreated = 3
 
-        (store.dailyMoments, store.dailyMoodRooms) = generateLastTwoMonths()
+        (store.dailyMoments, store.dailyMoodRooms) = generateLastThreeMonths()
 
         return store
     }
 
-    /// Generates random daily stats for the last two months.
-    fileprivate static func generateLastTwoMonths() -> ([String: TimeInterval], [String: TimeInterval]) {
+    /// Generates random daily stats for the last three months.
+    fileprivate static func generateLastThreeMonths() -> ([String: TimeInterval], [String: TimeInterval]) {
         let today = Date()
         var moments: [String: TimeInterval] = [:]
         var moods: [String: TimeInterval] = [:]
-        for offset in stride(from: -59, through: 0, by: 1) {
+        for offset in stride(from: -89, through: 0, by: 1) {
             if let date = Calendar.current.date(byAdding: .day, value: offset, to: today) {
                 let key = dayFormatter.string(from: date)
                 moments[key] = Double.random(in: 300...1800)

--- a/Luma/Luma/StatsView.swift
+++ b/Luma/Luma/StatsView.swift
@@ -39,7 +39,7 @@ struct StatsView: View {
 
                     Picker("Year", selection: $selectedYear) {
                         ForEach(availableYears, id: \.self) { year in
-                            Text("\(year)").tag(year)
+                            Text(String(year)).tag(year)
                         }
                     }
                     .pickerStyle(.menu)
@@ -63,6 +63,9 @@ struct StatsView: View {
                             selectedYear = availableYears.last ?? selectedYear
                         }
                     }
+
+                    colorLegend
+                        .padding(.horizontal, 16)
 
                     summary
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -106,6 +109,23 @@ struct StatsView: View {
         .cornerRadius(12)
     }
 
+    private var colorLegend: some View {
+        HStack(spacing: 16) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Color.blue)
+                    .frame(width: 10, height: 10)
+                Text("Moments")
+            }
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Color.purple)
+                    .frame(width: 10, height: 10)
+                Text("Mood rooms")
+            }
+        }
+    }
+
     private func chart(in geo: GeometryProxy) -> some View {
         let maxValue = aggregatedData
             .map { max($0.moments, $0.moods) / 60 }
@@ -128,7 +148,6 @@ struct StatsView: View {
                 }
             }
             .chartYScale(domain: 0...maxValue)
-            .chartLegend(position: .bottom, alignment: .center, spacing: nil)
             .frame(minWidth: max(geo.size.width - 32, CGFloat(aggregatedData.count) * 24))
             .padding(.horizontal, 16)
         }


### PR DESCRIPTION
## Summary
- extend `StatsStore` sample data to last three months
- ensure the year picker shows integer years
- remove default chart legend and add a custom color legend below the bar chart

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6883baf7ff6483319b262aff9ca9a0b0