### PR TITLE
Fix mood room duration wheel

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -190,7 +190,8 @@ struct CreateMoodRoomView: View {
                 .tint(interfaceColor)
                 .padding()
             }
-            .frame(width: UIScreen.main.bounds.width * 0.95)
+            .frame(width: UIScreen.main.bounds.width * 0.95,
+                   height: UIScreen.main.bounds.height * 0.7)
             .cornerRadius(16)
             .clipped()
             .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)


### PR DESCRIPTION
## Summary
- fix UI layout so the duration wheel in `CreateMoodRoomView` has enough space

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883c4c19acc8331a2a4eec2ed9819af