### PR TITLE
Fix duration wheel clipping in CreateMoodRoom

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -191,7 +191,8 @@ struct CreateMoodRoomView: View {
                 .padding()
             }
             .frame(width: UIScreen.main.bounds.width * 0.95,
-                   height: UIScreen.main.bounds.height * 0.7)
+                   height: UIScreen.main.bounds.height * (recurring ? 0.8 : 0.7))
+            .animation(.easeInOut, value: recurring)
             .cornerRadius(16)
             .clipped()
             .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)


### PR DESCRIPTION
## Summary
- size the mood room editor based on the recurring toggle
- animate the height change for smoother UI

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c783ce34833195141b2c8321b27f