### PR TITLE
Fix mood room menu height

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -192,7 +192,8 @@ struct CreateMoodRoomView: View {
                 .padding()
             }
             .frame(width: UIScreen.main.bounds.width * 0.95,
-                   height: UIScreen.main.bounds.height * 0.8)
+                   height: UIScreen.main.bounds.height * (recurring ? 0.8 : 0.7))
+            .animation(.easeInOut, value: recurring)
             .cornerRadius(16)
             .clipped()
             .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)


### PR DESCRIPTION
## Summary
- restore dynamic frame height in CreateMoodRoomView so the rectangle no longer stays expanded

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883cad57de88331965c8375a6aa664a