### PR TITLE
Set background of mood room editor

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -87,8 +87,14 @@ struct CreateMoodRoomView: View {
 
     /// Form UI with preview, date pickers and actions.
     var body: some View {
-        let interfaceColor: Color = backgrounds[backgroundIndex] == "MoodRoomNight" ? .white : .black
-        return VStack {
+        let interfaceColor: Color = .black
+        return ZStack {
+            Image("MainViewBackground")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+
+            VStack {
             Text(editingRoom == nil ? "Create a new mood room" : "Edit mood room")
                 .font(.headline)
                 .padding()
@@ -189,7 +195,7 @@ struct CreateMoodRoomView: View {
                         DatePicker("", selection: $time, displayedComponents: .hourAndMinute)
                             .labelsHidden()
                             .datePickerStyle(.wheel)
-                            .colorScheme(backgrounds[backgroundIndex] == "MoodRoomNight" ? .dark : .light)
+                            .colorScheme(.light)
                     }
                     .padding(.horizontal)
                     .padding(.bottom, -8)
@@ -212,7 +218,7 @@ struct CreateMoodRoomView: View {
                             }
                         }
                         .pickerStyle(.wheel)
-                        .colorScheme(backgrounds[backgroundIndex] == "MoodRoomNight" ? .dark : .light)
+                        .colorScheme(.light)
                     }
                     .padding(.horizontal)
                 }


### PR DESCRIPTION
## Summary
- show `MainViewBackground` behind Create Mood Room screen
- keep menu colors black even when selecting `MoodRoomNight`
- force a light color scheme for time and duration pickers

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883d16644808331bdcf97198e20e411