### PR TITLE
Replace Create Mood Room background image

### DIFF
--- a/Luma/Luma/CreateMoodRoomView.swift
+++ b/Luma/Luma/CreateMoodRoomView.swift
@@ -89,9 +89,7 @@ struct CreateMoodRoomView: View {
     var body: some View {
         let interfaceColor: Color = .black
         return ZStack {
-            Image("MainViewBackground")
-                .resizable()
-                .scaledToFill()
+            Color(red: 0.96, green: 0.89, blue: 0.76)
                 .ignoresSafeArea()
 
             VStack {


### PR DESCRIPTION
## Summary
- remove background image from `CreateMoodRoomView`
- use a light beige background color instead

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883d59e3d20833183593d470b1642c6