### PR TITLE
Integrate mood rooms with PostgreSQL backend

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,8 @@ import { ResonanceModule } from './resonance/resonance.module';
 import { Session } from './sessions/session.entity';
 import { Event } from './events/event.entity';
 import { Resonance } from './resonance/resonance.entity';
+import { MoodRoomsModule } from './moodrooms/moodrooms.module';
+import { MoodRoom } from './moodrooms/moodroom.entity';
 
 @Module({
   imports: [
@@ -19,11 +21,12 @@ import { Resonance } from './resonance/resonance.entity';
       password: process.env.DB_PASS || 'luma',
       database: process.env.DB_NAME || 'luma',
       synchronize: true,
-      entities: [Session, Event, Resonance],
+      entities: [Session, Event, Resonance, MoodRoom],
     }),
     SessionsModule,
     EventsModule,
     ResonanceModule,
+    MoodRoomsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/moodrooms/moodroom.entity.ts
+++ b/backend/src/moodrooms/moodroom.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Session } from '../sessions/session.entity';
+
+@Entity()
+export class MoodRoom {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  schedule: string;
+
+  @Column()
+  background: string;
+
+  @Column({ default: 'black' })
+  textColor: string;
+
+  @Column({ type: 'timestamptz' })
+  startTime: Date;
+
+  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @Column()
+  durationMinutes: number;
+
+  @ManyToOne(() => Session, (session) => session.moodRooms, {
+    onDelete: 'CASCADE',
+    nullable: true,
+  })
+  session?: Session;
+}

--- a/backend/src/moodrooms/moodrooms.controller.ts
+++ b/backend/src/moodrooms/moodrooms.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { MoodRoomsService } from './moodrooms.service';
+import { MoodRoom } from './moodroom.entity';
+
+@Controller('moodrooms')
+export class MoodRoomsController {
+  constructor(private readonly service: MoodRoomsService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Post()
+  create(@Query('session_token') token: string, @Body() body: MoodRoom) {
+    return this.service.create(token, body);
+  }
+}

--- a/backend/src/moodrooms/moodrooms.module.ts
+++ b/backend/src/moodrooms/moodrooms.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MoodRoom } from './moodroom.entity';
+import { MoodRoomsService } from './moodrooms.service';
+import { MoodRoomsController } from './moodrooms.controller';
+import { Session } from '../sessions/session.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MoodRoom, Session])],
+  controllers: [MoodRoomsController],
+  providers: [MoodRoomsService],
+})
+export class MoodRoomsModule {}

--- a/backend/src/moodrooms/moodrooms.service.ts
+++ b/backend/src/moodrooms/moodrooms.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MoodRoom } from './moodroom.entity';
+import { Session } from '../sessions/session.entity';
+
+@Injectable()
+export class MoodRoomsService {
+  constructor(
+    @InjectRepository(MoodRoom) private rooms: Repository<MoodRoom>,
+    @InjectRepository(Session) private sessions: Repository<Session>,
+  ) {}
+
+  list(): Promise<MoodRoom[]> {
+    return this.rooms.find({ relations: ['session'] });
+  }
+
+  async create(token: string, data: Partial<MoodRoom>): Promise<MoodRoom> {
+    let session = await this.sessions.findOne({ where: { token } });
+    if (!session) {
+      session = this.sessions.create({ token });
+      await this.sessions.save(session);
+    }
+    const room = this.rooms.create({ ...data, session });
+    return this.rooms.save(room);
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -2,16 +2,53 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DataSource } from 'typeorm';
 import { Event } from './events/event.entity';
+import { MoodRoom } from './moodrooms/moodroom.entity';
 
 async function bootstrap() {
   const app = await NestFactory.createApplicationContext(AppModule);
   const dataSource = app.get(DataSource);
   const count = await dataSource.getRepository(Event).count();
   if (count === 0) {
-    await dataSource.getRepository(Event).save([
-      { content: 'A sunny walk in the park' },
-      { content: 'Coffee with friends' },
-      { content: 'Reading a good book' },
+    await dataSource
+      .getRepository(Event)
+      .save([
+        { content: 'A sunny walk in the park' },
+        { content: 'Coffee with friends' },
+        { content: 'Reading a good book' },
+      ]);
+  }
+  const roomRepo = dataSource.getRepository(MoodRoom);
+  const roomCount = await roomRepo.count();
+  if (roomCount === 0) {
+    const now = new Date();
+    await roomRepo.save([
+      {
+        name: 'Monday Blues',
+        schedule: 'Every Monday at 17:30',
+        background: 'MoodRoomSad',
+        textColor: 'black',
+        startTime: new Date(now.getTime() + 600000),
+        durationMinutes: 30,
+        createdAt: now,
+      },
+      {
+        name: 'Mindful night routine',
+        schedule: 'Daily at 22:00',
+        background: 'MoodRoomNight',
+        textColor: 'white',
+        startTime: new Date(now.getTime() + 900000),
+        durationMinutes: 30,
+        createdAt: now,
+      },
+      {
+        name: 'Saturday for Reflection',
+        schedule: 'Every Saturday at 10:00',
+        background: 'MoodRoomNature',
+        textColor: 'black',
+        startTime: new Date(now.getTime() + 1200000),
+        durationMinutes: 30,
+        createdAt: now,
+      },
     ]);
   }
   await app.close();

--- a/backend/src/sessions/session.entity.ts
+++ b/backend/src/sessions/session.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { Event } from '../events/event.entity';
 import { Resonance } from '../resonance/resonance.entity';
+import { MoodRoom } from '../moodrooms/moodroom.entity';
 
 @Entity()
 export class Session {
@@ -15,4 +16,7 @@ export class Session {
 
   @OneToMany(() => Resonance, (resonance) => resonance.session)
   resonances: Resonance[];
+
+  @OneToMany(() => MoodRoom, (room) => room.session)
+  moodRooms: MoodRoom[];
 }

--- a/ios-app/Luma/ContentView.swift
+++ b/ios-app/Luma/ContentView.swift
@@ -14,6 +14,9 @@ struct ContentView: View {
     /// Fetches and creates moment events.
     @StateObject private var events = EventStore()
 
+    /// Stores mood rooms loaded from the backend.
+    @StateObject private var moodRooms = MoodRoomStore()
+
     /// Usage statistics shared across the app.
     @EnvironmentObject var stats: StatsStore
 
@@ -107,9 +110,13 @@ struct ContentView: View {
                     exploringMoodRooms = true
                     stats.recordMoodRoomCreated()
                 }
+                .environmentObject(moodRooms)
+                .environmentObject(session)
             }
             .fullScreenCover(isPresented: $exploringMoodRooms) {
                 MoodRoomListView()
+                    .environmentObject(moodRooms)
+                    .environmentObject(session)
             }
             .fullScreenCover(isPresented: $showStats) {
                 StatsView()
@@ -123,6 +130,7 @@ struct ContentView: View {
             .task {
                 await session.ensureSession()
                 await events.loadEvents()
+                await moodRooms.load(token: session.token)
             }
         }
     }

--- a/ios-app/Luma/Services/APIClient.swift
+++ b/ios-app/Luma/Services/APIClient.swift
@@ -7,7 +7,7 @@ class APIClient {
 
     /// Toggle this flag to use mock data instead of hitting the network.
     /// When `true` API calls return local ``MockData`` instead of hitting the backend.
-    static var useMock = true
+    static var useMock = false
 
     /// Base URL for the backend server.
     private let baseURL = URL(string: BASE_API_URL)!

--- a/ios-app/Luma/Services/MoodRoomService.swift
+++ b/ios-app/Luma/Services/MoodRoomService.swift
@@ -1,0 +1,74 @@
+import Foundation
+import SwiftUI
+
+struct NetworkMoodRoom: Codable {
+    var id: UUID
+    var name: String
+    var schedule: String
+    var background: String
+    var textColor: String
+    var startTime: Date
+    var createdAt: Date
+    var durationMinutes: Int
+    var sessionToken: String?
+}
+
+class MoodRoomService {
+    private let base = URL(string: BASE_API_URL)!
+
+    func fetchRooms() async throws -> [MoodRoom] {
+        if APIClient.useMock {
+            return MockData.moodRooms
+        }
+        let url = base.appendingPathComponent("moodrooms")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let decoded = try JSONDecoder().decode([NetworkMoodRoom].self, from: data)
+        return decoded.map { MoodRoom(id: $0.id,
+                                      name: $0.name,
+                                      schedule: $0.schedule,
+                                      background: $0.background,
+                                      textColor: $0.textColor.lowercased() == "white" ? .white : .black,
+                                      startTime: $0.startTime,
+                                      createdAt: $0.createdAt,
+                                      durationMinutes: $0.durationMinutes,
+                                      sessionToken: $0.sessionToken) }
+    }
+
+    func postRoom(token: String, room: MoodRoom) async throws -> MoodRoom {
+        if APIClient.useMock {
+            MockData.addMoodRoom(name: room.name,
+                                 schedule: room.schedule,
+                                 background: room.background,
+                                 textColor: room.textColor,
+                                 startTime: room.startTime,
+                                 durationMinutes: room.durationMinutes)
+            return MockData.userMoodRooms.first!
+        }
+        var comps = URLComponents(url: base.appendingPathComponent("moodrooms"), resolvingAgainstBaseURL: false)!
+        comps.queryItems = [URLQueryItem(name: "session_token", value: token)]
+        var request = URLRequest(url: comps.url!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let enc = NetworkMoodRoom(id: room.id,
+                                  name: room.name,
+                                  schedule: room.schedule,
+                                  background: room.background,
+                                  textColor: room.textColor == .white ? "white" : "black",
+                                  startTime: room.startTime,
+                                  createdAt: room.createdAt,
+                                  durationMinutes: room.durationMinutes,
+                                  sessionToken: nil)
+        request.httpBody = try JSONEncoder().encode(enc)
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let saved = try JSONDecoder().decode(NetworkMoodRoom.self, from: data)
+        return MoodRoom(id: saved.id,
+                        name: saved.name,
+                        schedule: saved.schedule,
+                        background: saved.background,
+                        textColor: saved.textColor.lowercased() == "white" ? .white : .black,
+                        startTime: saved.startTime,
+                        createdAt: saved.createdAt,
+                        durationMinutes: saved.durationMinutes,
+                        sessionToken: saved.sessionToken)
+    }
+}

--- a/ios-app/Luma/Services/MoodRoomStore.swift
+++ b/ios-app/Luma/Services/MoodRoomStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class MoodRoomStore: ObservableObject {
+    private let service = MoodRoomService()
+    @Published var rooms: [MoodRoom] = []
+
+    func load(token: String?) async {
+        do {
+            rooms = try await service.fetchRooms()
+        } catch {
+            print("Failed to load mood rooms", error)
+            rooms = []
+        }
+    }
+
+    func create(token: String, room: MoodRoom) async {
+        do {
+            _ = try await service.postRoom(token: token, room: room)
+            await load(token: token)
+        } catch {
+            print("Failed to create mood room", error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MoodRoom entity and NestJS module with CRUD routes
- seed preset mood rooms matching app defaults
- load mood rooms from the backend in the iOS app
- allow creating rooms via backend and disable mock mode by default

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a4e94e3008331b4a7f73fcc41c2d1