### PR TITLE
Fix moment creation

### DIFF
--- a/ios-app/Luma/Services/MomentService.swift
+++ b/ios-app/Luma/Services/MomentService.swift
@@ -25,7 +25,7 @@ class MomentService {
         var request = URLRequest(url: base.appendingPathComponent("moments"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(["text": text])
+        request.httpBody = try JSONEncoder().encode(["content": text])
         _ = try await URLSession.shared.data(for: request)
     }
 


### PR DESCRIPTION
## Summary
- send the `content` field when posting a new moment

## Testing
- `npm test` *(backend)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5c1b5a1c833185d76b7fff9bf715