### PR TITLE
Fix missing token when creating moments

### DIFF
--- a/ios-app/Luma/ContentView.swift
+++ b/ios-app/Luma/ContentView.swift
@@ -91,7 +91,8 @@ struct ContentView: View {
             }
             .sheet(isPresented: $creatingMoment) { CreateMomentView(text: $newEventText) { text in
                     Task {
-                        if let created = await events.createEvent(content: text) {
+                        if let token = session.token,
+                           let created = await events.createEvent(token: token, content: text) {
                             creatingMoment = false
                             newEventText = ""
                             selectedEvent = created

--- a/ios-app/Luma/Services/EventStore.swift
+++ b/ios-app/Luma/Services/EventStore.swift
@@ -23,9 +23,9 @@ class EventStore: ObservableObject {
     }
 
     /// Creates a new event and refreshes the list on success.
-    func createEvent(content: String) async -> Event? {
+    func createEvent(token: String, content: String) async -> Event? {
         do {
-            let created = try await momentService.postMoment(text: content)
+            let created = try await momentService.postMoment(token: token, text: content)
             await loadEvents()
             ownEventIds.insert(created.id)
             return Event(id: created.id, content: created.content, mood: nil, symbol: nil)

--- a/ios-app/Luma/Services/MomentService.swift
+++ b/ios-app/Luma/Services/MomentService.swift
@@ -17,11 +17,13 @@ class MomentService {
         return try JSONDecoder().decode([Moment].self, from: data)
     }
 
-    func postMoment(text: String) async throws -> Moment {
+    func postMoment(token: String, text: String) async throws -> Moment {
         if APIClient.useMock {
             return MockData.addEvent(content: text).toMoment()
         }
-        var request = URLRequest(url: base.appendingPathComponent("moments"))
+        var components = URLComponents(url: base.appendingPathComponent("moments"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "session_token", value: token)]
+        var request = URLRequest(url: components.url!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(["content": text])


### PR DESCRIPTION
## Summary
- include the session token when posting new moments
- update EventStore and ContentView to pass the token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a71d0ce1c8331aad47c364ce588da