### PR TITLE
Switch events to UUID identifiers

### DIFF
--- a/backend/src/events/event.entity.ts
+++ b/backend/src/events/event.entity.ts
@@ -3,8 +3,8 @@ import { Session } from '../sessions/session.entity';
 
 @Entity()
 export class Event {
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   content: string;

--- a/backend/src/events/events.controller.ts
+++ b/backend/src/events/events.controller.ts
@@ -20,6 +20,6 @@ export class EventsController {
 
   @Get(':id')
   fetch(@Param('id') id: string) {
-    return this.eventsService.find(parseInt(id, 10));
+    return this.eventsService.find(id);
   }
 }

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -31,7 +31,7 @@ export class EventsService {
     return this.events.save(event);
   }
 
-  async find(id: number): Promise<Event | null> {
+  async find(id: string): Promise<Event | null> {
     return this.events.findOne({ where: { id } });
   }
 }

--- a/backend/src/resonance/resonance.controller.ts
+++ b/backend/src/resonance/resonance.controller.ts
@@ -8,7 +8,7 @@ export class ResonanceController {
   @Post()
   create(
     @Query('session_token') token: string,
-    @Body('momentId') momentId: number,
+    @Body('momentId') momentId: string,
   ) {
     return this.service.create(token, momentId);
   }

--- a/backend/src/resonance/resonance.service.ts
+++ b/backend/src/resonance/resonance.service.ts
@@ -14,7 +14,7 @@ export class ResonanceService {
     @InjectRepository(Event) private events: Repository<Event>,
   ) {}
 
-  async create(token: string, eventId: number) {
+  async create(token: string, eventId: string) {
     if (!isUUID(token)) {
       throw new BadRequestException('Invalid session token');
     }

--- a/ios-app/Luma/MockData.swift
+++ b/ios-app/Luma/MockData.swift
@@ -4,9 +4,9 @@ import SwiftUI
 /// In-memory structures used when ``APIClient.useMock`` is `true`.
 class MockData {
     static var events: [Event] = [
-        Event(id: 1, content: "A sunny walk in the park", mood: nil, symbol: nil),
-        Event(id: 2, content: "Coffee with friends", mood: nil, symbol: nil),
-        Event(id: 3, content: "Reading a good book", mood: nil, symbol: nil)
+        Event(id: UUID(), content: "A sunny walk in the park", mood: nil, symbol: nil),
+        Event(id: UUID(), content: "Coffee with friends", mood: nil, symbol: nil),
+        Event(id: UUID(), content: "Reading a good book", mood: nil, symbol: nil)
     ]
 
     static var presetMoodRooms: [MoodRoom] = [
@@ -85,14 +85,13 @@ class MockData {
 
     /// Adds and returns a new event with a unique identifier.
     static func addEvent(content: String) -> Event {
-        let newId = (events.map { $0.id }.max() ?? 0) + 1
-        let event = Event(id: newId, content: content, mood: nil, symbol: nil)
+        let event = Event(id: UUID(), content: content, mood: nil, symbol: nil)
         events.append(event)
         return event
     }
 
     /// Returns an event matching the given identifier if present.
-    static func event(id: Int) -> Event? {
+    static func event(id: UUID) -> Event? {
         events.first { $0.id == id }
     }
 }

--- a/ios-app/Luma/Services/APIClient.swift
+++ b/ios-app/Luma/Services/APIClient.swift
@@ -54,12 +54,12 @@ class APIClient {
     }
 
     /// Fetches the full details for a single event by id.
-    func fetchEvent(id: Int) async throws -> Event {
+    func fetchEvent(id: UUID) async throws -> Event {
         if APIClient.useMock {
             return MockData.event(id: id) ?? MockData.events.first!
         }
 
-        let url = baseURL.appendingPathComponent("moments/\(id)")
+        let url = baseURL.appendingPathComponent("moments/\(id.uuidString)")
         let (data, _) = try await URLSession.shared.data(from: url)
         return try JSONDecoder().decode(Event.self, from: data)
     }

--- a/ios-app/Luma/Services/EventStore.swift
+++ b/ios-app/Luma/Services/EventStore.swift
@@ -8,7 +8,7 @@ class EventStore: ObservableObject {
     @Published var events: [Event] = []
 
     /// Identifiers of events created by the current session.
-    @Published var ownEventIds: Set<Int> = []
+    @Published var ownEventIds: Set<UUID> = []
 
     /// Fetches events from the backend into ``events``.
     func loadEvents() async {

--- a/ios-app/Luma/Services/Models.swift
+++ b/ios-app/Luma/Services/Models.swift
@@ -5,7 +5,7 @@ struct Session: Codable {
 }
 
 struct Event: Codable, Identifiable {
-    let id: Int
+    let id: UUID
     let content: String
     let mood: String?
     let symbol: String?

--- a/ios-app/Luma/Services/MomentService.swift
+++ b/ios-app/Luma/Services/MomentService.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct Moment: Codable, Identifiable {
-    let id: Int
+    let id: UUID
     let content: String
 }
 

--- a/ios-app/Luma/Services/PresenceService.swift
+++ b/ios-app/Luma/Services/PresenceService.swift
@@ -9,7 +9,7 @@ class PresenceService: ObservableObject {
     private var task: URLSessionWebSocketTask?
 
     /// Opens the WebSocket for the specified event.
-    func connect(eventId: Int) {
+    func connect(eventId: UUID) {
         disconnect()
 
         guard !APIClient.useMock else {
@@ -22,7 +22,7 @@ class PresenceService: ObservableObject {
         urlComponents.scheme = "ws"
         urlComponents.host = "localhost"
         urlComponents.port = 8000
-        urlComponents.path = "/ws/presence/\(eventId)"
+        urlComponents.path = "/ws/presence/\(eventId.uuidString)"
         guard let url = urlComponents.url else { return }
         task = URLSession(configuration: .default).webSocketTask(with: url)
         task?.resume()


### PR DESCRIPTION
## Summary
- change backend event entity to use `uuid` primary key
- update controllers and services for string IDs
- adjust resonance endpoints to accept UUID event IDs
- migrate iOS models to `UUID` identifiers
- update presence service and mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8d4fa87083319296de7367ea5794