### PR TITLE
Use UUID for resonance entity id

### DIFF
--- a/backend/src/resonance/resonance.entity.ts
+++ b/backend/src/resonance/resonance.entity.ts
@@ -4,8 +4,8 @@ import { Event } from '../events/event.entity';
 
 @Entity()
 export class Resonance {
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @ManyToOne(() => Session, (session) => session.resonances, {
     onDelete: 'CASCADE',


### PR DESCRIPTION
## Summary
- enforce GUID primary key for `Resonance` entity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a95b6c31c8331b1bc29b1dcbf6819