### PR TITLE
Use string GUIDs in iOS models

### DIFF
--- a/ios-app/Luma/EventCardView.swift
+++ b/ios-app/Luma/EventCardView.swift
@@ -39,5 +39,5 @@ struct EventCardView: View {
 
 #Preview {
     // Preview showing the card with example content.
-    EventCardView(event: Event(id: UUID(), content: "Hello world", mood: nil, symbol: nil), isOwnEvent: true)
+    EventCardView(event: Event(id: UUID().uuidString, content: "Hello world", mood: nil, symbol: nil), isOwnEvent: true)
 }

--- a/ios-app/Luma/MockData.swift
+++ b/ios-app/Luma/MockData.swift
@@ -4,9 +4,9 @@ import SwiftUI
 /// In-memory structures used when ``APIClient.useMock`` is `true`.
 class MockData {
     static var events: [Event] = [
-        Event(id: UUID(), content: "A sunny walk in the park", mood: nil, symbol: nil),
-        Event(id: UUID(), content: "Coffee with friends", mood: nil, symbol: nil),
-        Event(id: UUID(), content: "Reading a good book", mood: nil, symbol: nil)
+        Event(id: UUID().uuidString, content: "A sunny walk in the park", mood: nil, symbol: nil),
+        Event(id: UUID().uuidString, content: "Coffee with friends", mood: nil, symbol: nil),
+        Event(id: UUID().uuidString, content: "Reading a good book", mood: nil, symbol: nil)
     ]
 
     static var presetMoodRooms: [MoodRoom] = [
@@ -85,13 +85,13 @@ class MockData {
 
     /// Adds and returns a new event with a unique identifier.
     static func addEvent(content: String) -> Event {
-        let event = Event(id: UUID(), content: content, mood: nil, symbol: nil)
+        let event = Event(id: UUID().uuidString, content: content, mood: nil, symbol: nil)
         events.append(event)
         return event
     }
 
     /// Returns an event matching the given identifier if present.
-    static func event(id: UUID) -> Event? {
+    static func event(id: String) -> Event? {
         events.first { $0.id == id }
     }
 }

--- a/ios-app/Luma/Services/APIClient.swift
+++ b/ios-app/Luma/Services/APIClient.swift
@@ -54,12 +54,12 @@ class APIClient {
     }
 
     /// Fetches the full details for a single event by id.
-    func fetchEvent(id: UUID) async throws -> Event {
+    func fetchEvent(id: String) async throws -> Event {
         if APIClient.useMock {
             return MockData.event(id: id) ?? MockData.events.first!
         }
 
-        let url = baseURL.appendingPathComponent("moments/\(id.uuidString)")
+        let url = baseURL.appendingPathComponent("moments/\(id)")
         let (data, _) = try await URLSession.shared.data(from: url)
         return try JSONDecoder().decode(Event.self, from: data)
     }

--- a/ios-app/Luma/Services/EventStore.swift
+++ b/ios-app/Luma/Services/EventStore.swift
@@ -8,7 +8,7 @@ class EventStore: ObservableObject {
     @Published var events: [Event] = []
 
     /// Identifiers of events created by the current session.
-    @Published var ownEventIds: Set<UUID> = []
+    @Published var ownEventIds: Set<String> = []
 
     /// Fetches events from the backend into ``events``.
     func loadEvents() async {

--- a/ios-app/Luma/Services/Models.swift
+++ b/ios-app/Luma/Services/Models.swift
@@ -5,7 +5,8 @@ struct Session: Codable {
 }
 
 struct Event: Codable, Identifiable {
-    let id: UUID
+    /// Unique identifier represented as a GUID string.
+    let id: String
     let content: String
     let mood: String?
     let symbol: String?

--- a/ios-app/Luma/Services/MomentService.swift
+++ b/ios-app/Luma/Services/MomentService.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 struct Moment: Codable, Identifiable {
-    let id: UUID
+    /// Unique identifier represented as a GUID string.
+    let id: String
     let content: String
 }
 
@@ -31,12 +32,12 @@ class MomentService {
         return try JSONDecoder().decode(Moment.self, from: data)
     }
 
-    func postResonance(momentId: UUID) async throws {
+    func postResonance(momentId: String) async throws {
         if APIClient.useMock { return }
         var request = URLRequest(url: base.appendingPathComponent("resonance"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(["momentId": momentId.uuidString])
+        request.httpBody = try JSONEncoder().encode(["momentId": momentId])
         _ = try await URLSession.shared.data(for: request)
     }
 }

--- a/ios-app/Luma/Services/PresenceService.swift
+++ b/ios-app/Luma/Services/PresenceService.swift
@@ -9,7 +9,7 @@ class PresenceService: ObservableObject {
     private var task: URLSessionWebSocketTask?
 
     /// Opens the WebSocket for the specified event.
-    func connect(eventId: UUID) {
+    func connect(eventId: String) {
         disconnect()
 
         guard !APIClient.useMock else {
@@ -22,7 +22,7 @@ class PresenceService: ObservableObject {
         urlComponents.scheme = "ws"
         urlComponents.host = "localhost"
         urlComponents.port = 8000
-        urlComponents.path = "/ws/presence/\(eventId.uuidString)"
+        urlComponents.path = "/ws/presence/\(eventId)"
         guard let url = urlComponents.url else { return }
         task = URLSession(configuration: .default).webSocketTask(with: url)
         task?.resume()


### PR DESCRIPTION
## Summary
- represent event IDs as GUID strings
- update API client, stores and services to work with string IDs
- adjust mock data and previews for new ID type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9baff7708331b594c795c635194c