### PR TITLE
Implement session token management

### DIFF
--- a/backend/src/moodrooms/moodrooms.service.ts
+++ b/backend/src/moodrooms/moodrooms.service.ts
@@ -17,6 +17,9 @@ export class MoodRoomsService {
   }
 
   async create(token: string, data: Partial<MoodRoom>): Promise<MoodRoom> {
+    if (!token) {
+      throw new BadRequestException('No session token available');
+    }
     if (!isUUID(token)) {
       throw new BadRequestException('Invalid session token');
     }

--- a/backend/src/resonance/resonance.service.ts
+++ b/backend/src/resonance/resonance.service.ts
@@ -15,6 +15,9 @@ export class ResonanceService {
   ) {}
 
   async create(token: string, eventId: string) {
+    if (!token) {
+      throw new BadRequestException('No session token available');
+    }
     if (!isUUID(token)) {
       throw new BadRequestException('Invalid session token');
     }

--- a/ios-app/Luma/CreateMoodRoomView.swift
+++ b/ios-app/Luma/CreateMoodRoomView.swift
@@ -254,6 +254,10 @@ struct CreateMoodRoomView: View {
                             } else {
                                 schedule = "Once at \(timeString)"
                             }
+                            guard let token = session.token, !token.isEmpty else {
+                                print("❌ Kein Session-Token verfügbar – Mood Room wird nicht erstellt.")
+                                return
+                            }
                             if let editing = editingRoom {
                                 let updated = MoodRoom(id: editing.id,
                                                        name: name.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -263,8 +267,8 @@ struct CreateMoodRoomView: View {
                                                        startTime: time,
                                                        createdAt: editing.createdAt,
                                                        durationMinutes: durationMinutes,
-                                                       sessionToken: session.token)
-                                await store.create(token: session.token ?? "", room: updated)
+                                                       sessionToken: token)
+                                await store.create(token: token, room: updated)
                                 onUpdate(updated)
                             } else {
                                 let newRoom = MoodRoom(name: name.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -274,8 +278,8 @@ struct CreateMoodRoomView: View {
                                                        startTime: time,
                                                        createdAt: Date(),
                                                        durationMinutes: durationMinutes,
-                                                       sessionToken: session.token)
-                                await store.create(token: session.token ?? "", room: newRoom)
+                                                       sessionToken: token)
+                                await store.create(token: token, room: newRoom)
                                 onCreate(newRoom.name, newRoom.background)
                             }
                             dismiss()

--- a/ios-app/Luma/Services/APIClient.swift
+++ b/ios-app/Luma/Services/APIClient.swift
@@ -17,7 +17,7 @@ class APIClient {
     /// Creates an anonymous user session on the backend.
     func createSession() async throws -> Session {
         if APIClient.useMock {
-            return Session(token: "mock-token")
+            return Session(token: UUID().uuidString)
         }
 
         var request = URLRequest(url: baseURL.appendingPathComponent("session"))

--- a/ios-app/Luma/Services/SessionStore.swift
+++ b/ios-app/Luma/Services/SessionStore.swift
@@ -22,10 +22,6 @@ class SessionStore: ObservableObject {
             UserDefaults.standard.set(sess.token, forKey: key)
         } catch {
             print("Session creation failed", error)
-            // Only fall back to a mock token when the app is in mock mode
-            if APIClient.useMock {
-                token = "mock-token"
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- generate unique session token for mocks
- remove fallback mock token from `SessionStore`
- validate missing tokens in mood room and resonance services
- require a valid token when creating mood rooms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b41d8abf88331bf5ef037c5f56344