### PR TITLE
Fix session token for moment creation

### DIFF
--- a/ios-app/Luma/Services/APIClient.swift
+++ b/ios-app/Luma/Services/APIClient.swift
@@ -28,12 +28,12 @@ class APIClient {
 
     /// Posts a new event using the provided session token.
     func createEvent(token: String, event: EventCreate) async throws -> Event {
-        var components = URLComponents(url: baseURL.appendingPathComponent("moments"), resolvingAgainstBaseURL: false)!
-        components.queryItems = [URLQueryItem(name: "session_token", value: token)]
-        var request = URLRequest(url: components.url!)
+        let url = baseURL.appendingPathComponent("moments")
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(event)
+        let payload = ["content": event.content, "mood": event.mood, "symbol": event.symbol, "session_token": token]
+        request.httpBody = try JSONEncoder().encode(payload)
         let (data, _) = try await URLSession.shared.data(for: request)
         return try JSONDecoder().decode(Event.self, from: data)
     }

--- a/ios-app/Luma/Services/MomentService.swift
+++ b/ios-app/Luma/Services/MomentService.swift
@@ -16,12 +16,11 @@ class MomentService {
     }
 
     func postMoment(token: String, text: String) async throws -> Moment {
-        var components = URLComponents(url: base.appendingPathComponent("moments"), resolvingAgainstBaseURL: false)!
-        components.queryItems = [URLQueryItem(name: "session_token", value: token)]
-        var request = URLRequest(url: components.url!)
+        let url = base.appendingPathComponent("moments")
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(["content": text])
+        request.httpBody = try JSONEncoder().encode(["content": text, "session_token": token])
         let (data, _) = try await URLSession.shared.data(for: request)
         print("📥 Raw response:", String(data: data, encoding: .utf8) ?? "nil")
         return try JSONDecoder().decode(Moment.self, from: data)


### PR DESCRIPTION
## Summary
- pass session token in POST body when creating moments
- adjust API client accordingly

## Testing
- `npm -C backend install --no-audit`
- `npm -C backend test`

------
https://chatgpt.com/codex/tasks/task_e_688b50980c888331960973e6b5355c06