### PR TITLE
Implement MoodRoom favorites

### DIFF
--- a/ios-app/Luma/ContentView.swift
+++ b/ios-app/Luma/ContentView.swift
@@ -17,6 +17,9 @@ struct ContentView: View {
     /// Stores mood rooms loaded from the backend.
     @StateObject private var moodRooms = MoodRoomStore()
 
+    /// Persists favourite mood rooms.
+    @StateObject private var favourites = FavoritesStore()
+
     /// Usage statistics shared across the app.
     @EnvironmentObject var stats: StatsStore
 
@@ -52,6 +55,27 @@ struct ContentView: View {
                     .ignoresSafeArea()
 
                 ScrollView {
+                    let favRooms = moodRooms.rooms.filter { favourites.isFavorite($0) }
+                    if !favRooms.isEmpty {
+                        LazyVStack(spacing: 16) {
+                            Text("Scheduled MoodRooms")
+                                .font(.headline)
+                                .foregroundColor(.black)
+                            ForEach(favRooms) { room in
+                                if room.isJoinable {
+                                    NavigationLink(destination: MoodRoomView(room: room)) {
+                                        MoodRoomCardView(room: room)
+                                            .id(room)
+                                    }
+                                } else {
+                                    MoodRoomCardView(room: room)
+                                        .id(room)
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical)
+                    }
                     if events.events.isEmpty {
                         Text("No entries")
                             .foregroundColor(.secondary)
@@ -122,6 +146,7 @@ struct ContentView: View {
                 MoodRoomListView()
                     .environmentObject(moodRooms)
                     .environmentObject(session)
+                    .environmentObject(favourites)
             }
             .fullScreenCover(isPresented: $showStats) {
                 StatsView()
@@ -179,4 +204,7 @@ struct EnergyRoomView: View {
 #Preview {
     // Basic preview for Xcode canvas.
     ContentView()
+        .environmentObject(StatsStore())
+        .environmentObject(SessionStore())
+        .environmentObject(FavoritesStore())
 }

--- a/ios-app/Luma/MoodRoomCardView.swift
+++ b/ios-app/Luma/MoodRoomCardView.swift
@@ -5,6 +5,9 @@ struct MoodRoomCardView: View {
     /// Room to visualise.
     let room: MoodRoom
 
+    /// Provides access to favourite state.
+    @EnvironmentObject private var favourites: FavoritesStore
+
     /// View body showing the background image and text.
     var body: some View {
         let cardWidth = UIScreen.main.bounds.width * 0.95
@@ -31,11 +34,20 @@ struct MoodRoomCardView: View {
         .frame(width: cardWidth, height: cardHeight)
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
-            if !room.isJoinable {
-                Text("Unavailable at the moment")
-                    .font(.caption2)
-                    .foregroundColor(room.textColor)
-                    .padding(6)
+            VStack(alignment: .trailing, spacing: 2) {
+                Button(action: { favourites.toggle(room) }) {
+                    Image(systemName: favourites.isFavorite(room) ? "star.fill" : "star")
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        .foregroundColor(favourites.isFavorite(room) ? (room.background == "MoodRoomNight" ? .white : .black) : .black)
+                        .padding(6)
+                }
+                if !room.isJoinable {
+                    Text("Unavailable at the moment")
+                        .font(.caption2)
+                        .foregroundColor(room.textColor)
+                        .padding(6)
+                }
             }
         }
         .allowsHitTesting(room.isJoinable)
@@ -51,4 +63,5 @@ struct MoodRoomCardView: View {
                                    startTime: Date(),
                                    createdAt: Date(),
                                    durationMinutes: 30))
+        .environmentObject(FavoritesStore())
 }

--- a/ios-app/Luma/MoodRoomListView.swift
+++ b/ios-app/Luma/MoodRoomListView.swift
@@ -8,6 +8,9 @@ struct MoodRoomListView: View {
     /// Access to the current session token.
     @EnvironmentObject private var session: SessionStore
 
+    /// Favourite mood rooms store.
+    @EnvironmentObject private var favourites: FavoritesStore
+
     /// Loads rooms from the backend.
     @StateObject private var store = MoodRoomStore()
 
@@ -115,4 +118,6 @@ struct MoodRoomListView: View {
 #Preview {
     // Preview showing all mood rooms.
     MoodRoomListView()
+        .environmentObject(SessionStore())
+        .environmentObject(FavoritesStore())
 }

--- a/ios-app/Luma/MoodRoomView.swift
+++ b/ios-app/Luma/MoodRoomView.swift
@@ -180,4 +180,5 @@ struct MoodRoomView: View {
                                 createdAt: Date(),
                                 durationMinutes: 15),
                  isPreview: true)
+        .environmentObject(StatsStore())
 }

--- a/ios-app/Luma/Services/FavoritesStore.swift
+++ b/ios-app/Luma/Services/FavoritesStore.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class FavoritesStore: ObservableObject {
+    @Published private(set) var favoriteIds: Set<UUID>
+    private let key = "favoriteMoodRooms"
+
+    init() {
+        if let stored = UserDefaults.standard.array(forKey: key) as? [String] {
+            favoriteIds = Set(stored.compactMap { UUID(uuidString: $0) })
+        } else {
+            favoriteIds = []
+        }
+    }
+
+    func isFavorite(_ room: MoodRoom) -> Bool {
+        favoriteIds.contains(room.id)
+    }
+
+    func toggle(_ room: MoodRoom) {
+        if favoriteIds.contains(room.id) {
+            favoriteIds.remove(room.id)
+        } else {
+            favoriteIds.insert(room.id)
+        }
+        save()
+    }
+
+    private func save() {
+        let arr = favoriteIds.map { $0.uuidString }
+        UserDefaults.standard.set(arr, forKey: key)
+    }
+}


### PR DESCRIPTION
## Summary
- add `FavoritesStore` to manage starred mood rooms
- show favorite toggle on every `MoodRoomCardView`
- list favorites on the home screen under "Scheduled MoodRooms"
- plumb favorites environment object across views

## Testing
- `npm test --silent`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688b63fa427c8331ad83bfa88961e4e5