### PR TITLE
Add server-managed favorites

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,10 @@ import { Event } from './events/event.entity';
 import { Resonance } from './resonance/resonance.entity';
 import { MoodRoomsModule } from './moodrooms/moodrooms.module';
 import { MoodRoom } from './moodrooms/moodroom.entity';
+import { FavoritesModule } from './favorites/favorites.module';
+import { FavoriteMoodRoom } from './favorites/favorite-moodroom.entity';
+import { UsersModule } from './users/users.module';
+import { User } from './users/user.entity';
 
 @Module({
   imports: [
@@ -21,12 +25,14 @@ import { MoodRoom } from './moodrooms/moodroom.entity';
       password: process.env.DB_PASS || 'luma',
       database: process.env.DB_NAME || 'luma',
       synchronize: true,
-      entities: [Session, Event, Resonance, MoodRoom],
+      entities: [Session, Event, Resonance, MoodRoom, FavoriteMoodRoom, User],
     }),
     SessionsModule,
     EventsModule,
     ResonanceModule,
     MoodRoomsModule,
+    FavoritesModule,
+    UsersModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/favorites/favorite-moodroom.entity.ts
+++ b/backend/src/favorites/favorite-moodroom.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, Unique } from 'typeorm';
+import { User } from '../users/user.entity';
+import { MoodRoom } from '../moodrooms/moodroom.entity';
+
+@Entity()
+@Unique(['user', 'moodRoom'])
+export class FavoriteMoodRoom {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, { eager: true, onDelete: 'CASCADE' })
+  user: User;
+
+  @ManyToOne(() => MoodRoom, { eager: true, onDelete: 'CASCADE' })
+  moodRoom: MoodRoom;
+
+  @Column({ type: 'timestamptz' })
+  favoritedAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  unfavoritedAt?: Date | null;
+}

--- a/backend/src/favorites/favorites.controller.ts
+++ b/backend/src/favorites/favorites.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { FavoritesService } from './favorites.service';
+
+@Controller('favorites')
+export class FavoritesController {
+  constructor(private readonly service: FavoritesService) {}
+
+  @Post()
+  toggle(@Body() body: { userId: string; moodRoomId: string }) {
+    return this.service.toggle(body.userId, body.moodRoomId);
+  }
+
+  @Get(':userId')
+  list(@Param('userId') userId: string) {
+    return this.service.list(userId);
+  }
+}

--- a/backend/src/favorites/favorites.module.ts
+++ b/backend/src/favorites/favorites.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FavoriteMoodRoom } from './favorite-moodroom.entity';
+import { FavoritesService } from './favorites.service';
+import { FavoritesController } from './favorites.controller';
+import { User } from '../users/user.entity';
+import { MoodRoom } from '../moodrooms/moodroom.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FavoriteMoodRoom, User, MoodRoom])],
+  providers: [FavoritesService],
+  controllers: [FavoritesController],
+  exports: [FavoritesService],
+})
+export class FavoritesModule {}

--- a/backend/src/favorites/favorites.service.ts
+++ b/backend/src/favorites/favorites.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, IsNull } from 'typeorm';
+import { FavoriteMoodRoom } from './favorite-moodroom.entity';
+import { User } from '../users/user.entity';
+import { MoodRoom } from '../moodrooms/moodroom.entity';
+
+@Injectable()
+export class FavoritesService {
+  constructor(
+    @InjectRepository(FavoriteMoodRoom) private favorites: Repository<FavoriteMoodRoom>,
+    @InjectRepository(User) private users: Repository<User>,
+    @InjectRepository(MoodRoom) private rooms: Repository<MoodRoom>,
+  ) {}
+
+  async toggle(userId: string, moodRoomId: string): Promise<{ isFavorite: boolean }> {
+    let user = await this.users.findOne({ where: { id: userId } });
+    if (!user) {
+      user = this.users.create({ id: userId });
+      await this.users.save(user);
+    }
+    const room = await this.rooms.findOne({ where: { id: moodRoomId } });
+    if (!room) {
+      throw new NotFoundException('MoodRoom not found');
+    }
+    let fav = await this.favorites.findOne({ where: { user: { id: userId }, moodRoom: { id: moodRoomId } } });
+    if (!fav) {
+      fav = this.favorites.create({ user, moodRoom: room, favoritedAt: new Date(), unfavoritedAt: null });
+      await this.favorites.save(fav);
+      return { isFavorite: true };
+    }
+    if (fav.unfavoritedAt) {
+      fav.unfavoritedAt = null;
+      fav.favoritedAt = new Date();
+      await this.favorites.save(fav);
+      return { isFavorite: true };
+    }
+    fav.unfavoritedAt = new Date();
+    await this.favorites.save(fav);
+    return { isFavorite: false };
+  }
+
+  async list(userId: string): Promise<MoodRoom[]> {
+    const favs = await this.favorites.find({
+      where: { user: { id: userId }, unfavoritedAt: IsNull() },
+      relations: ['moodRoom', 'moodRoom.session'],
+    });
+    return favs.map((f) => f.moodRoom);
+  }
+}

--- a/backend/src/moodrooms/moodrooms.controller.ts
+++ b/backend/src/moodrooms/moodrooms.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, Param } from '@nestjs/common';
 import { MoodRoomsService } from './moodrooms.service';
 import { MoodRoom } from './moodroom.entity';
 
@@ -9,6 +9,11 @@ export class MoodRoomsController {
   @Get()
   list() {
     return this.service.list();
+  }
+
+  @Get(':userId')
+  listForUser(@Param('userId') userId: string) {
+    return this.service.listWithFavorites(userId);
   }
 
   @Post()

--- a/backend/src/moodrooms/moodrooms.module.ts
+++ b/backend/src/moodrooms/moodrooms.module.ts
@@ -4,9 +4,11 @@ import { MoodRoom } from './moodroom.entity';
 import { MoodRoomsService } from './moodrooms.service';
 import { MoodRoomsController } from './moodrooms.controller';
 import { Session } from '../sessions/session.entity';
+import { FavoriteMoodRoom } from '../favorites/favorite-moodroom.entity';
+import { User } from '../users/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MoodRoom, Session])],
+  imports: [TypeOrmModule.forFeature([MoodRoom, Session, FavoriteMoodRoom, User])],
   controllers: [MoodRoomsController],
   providers: [MoodRoomsService],
 })

--- a/backend/src/moodrooms/moodrooms.service.ts
+++ b/backend/src/moodrooms/moodrooms.service.ts
@@ -1,19 +1,30 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, IsNull } from 'typeorm';
 import { MoodRoom } from './moodroom.entity';
 import { Session } from '../sessions/session.entity';
 import { validate as isUUID } from 'uuid';
+import { FavoriteMoodRoom } from '../favorites/favorite-moodroom.entity';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class MoodRoomsService {
   constructor(
     @InjectRepository(MoodRoom) private rooms: Repository<MoodRoom>,
     @InjectRepository(Session) private sessions: Repository<Session>,
+    @InjectRepository(FavoriteMoodRoom) private favorites: Repository<FavoriteMoodRoom>,
+    @InjectRepository(User) private users: Repository<User>,
   ) {}
 
   list(): Promise<MoodRoom[]> {
     return this.rooms.find({ relations: ['session'] });
+  }
+
+  async listWithFavorites(userId: string): Promise<(MoodRoom & { isFavorite: boolean })[]> {
+    const rooms = await this.rooms.find({ relations: ['session'] });
+    const favs = await this.favorites.find({ where: { user: { id: userId }, unfavoritedAt: IsNull() } });
+    const favIds = new Set(favs.map((f) => f.moodRoom.id));
+    return rooms.map((r) => ({ ...r, isFavorite: favIds.has(r.id) }));
   }
 
   async create(token: string, data: Partial<MoodRoom>): Promise<MoodRoom> {

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryColumn('uuid')
+  id: string;
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  exports: [TypeOrmModule],
+})
+export class UsersModule {}

--- a/ios-app/Luma/ContentView.swift
+++ b/ios-app/Luma/ContentView.swift
@@ -44,6 +44,8 @@ struct ContentView: View {
 
     /// Controls presentation of the statistics screen.
     @State private var showStats = false
+    /// Controls presentation of the scheduled rooms list.
+    @State private var showScheduled = false
 
     /// Main screen with a list of moments and toolbar actions.
     var body: some View {
@@ -99,6 +101,7 @@ struct ContentView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Menu {
                         Button("Explore Mood Rooms") { exploringMoodRooms = true }
+                        Button("Scheduled MoodRooms") { showScheduled = true }
                         Button("New Mood Room") { creatingMoodRoom = true }
                         Button("New Moment") { creatingMoment = true }
                         Button("Statistics") { showStats = true }
@@ -148,6 +151,11 @@ struct ContentView: View {
                     .environmentObject(session)
                     .environmentObject(favourites)
             }
+            .fullScreenCover(isPresented: $showScheduled) {
+                ScheduledMoodRoomListView()
+                    .environmentObject(favourites)
+                    .environmentObject(session)
+            }
             .fullScreenCover(isPresented: $showStats) {
                 StatsView()
                     .environmentObject(stats)
@@ -160,7 +168,8 @@ struct ContentView: View {
             .task {
                 await session.ensureSession()
                 await events.loadEvents()
-                await moodRooms.load(token: session.token)
+                await moodRooms.load(token: session.token, userId: HARDCODED_USER_ID)
+                await favourites.loadFavorites()
             }
         }
     }

--- a/ios-app/Luma/MoodRoomCardView.swift
+++ b/ios-app/Luma/MoodRoomCardView.swift
@@ -35,7 +35,9 @@ struct MoodRoomCardView: View {
         .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
             VStack(alignment: .trailing, spacing: 2) {
-                Button(action: { favourites.toggle(room) }) {
+                Button(action: {
+                    Task { await favourites.toggle(room) }
+                }) {
                     Image(systemName: favourites.isFavorite(room) ? "star.fill" : "star")
                         .resizable()
                         .frame(width: 16, height: 16)

--- a/ios-app/Luma/MoodRoomListView.swift
+++ b/ios-app/Luma/MoodRoomListView.swift
@@ -110,7 +110,8 @@ struct MoodRoomListView: View {
             }
         }
         .task {
-            await store.load(token: session.token)
+            await store.load(token: session.token, userId: HARDCODED_USER_ID)
+            await favourites.loadFavorites()
         }
     }
 }

--- a/ios-app/Luma/ScheduledMoodRoomListView.swift
+++ b/ios-app/Luma/ScheduledMoodRoomListView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct ScheduledMoodRoomListView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var favourites: FavoritesStore
+    @EnvironmentObject private var session: SessionStore
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Image("MainViewBackground")
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(favourites.rooms) { room in
+                            if room.isJoinable {
+                                NavigationLink(destination: MoodRoomView(room: room)) {
+                                    MoodRoomCardView(room: room)
+                                }
+                            } else {
+                                MoodRoomCardView(room: room)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical)
+                }
+            }
+            .navigationTitle("Scheduled MoodRooms")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(.black)
+                }
+            }
+        }
+        .task {
+            await favourites.loadFavorites()
+        }
+    }
+}
+
+#Preview {
+    ScheduledMoodRoomListView()
+        .environmentObject(FavoritesStore())
+        .environmentObject(SessionStore())
+}

--- a/ios-app/Luma/Services/Constants.swift
+++ b/ios-app/Luma/Services/Constants.swift
@@ -1,3 +1,4 @@
 import Foundation
 
 let BASE_API_URL = "http://localhost:3000"
+let HARDCODED_USER_ID = "00000000-0000-0000-0000-000000000001"

--- a/ios-app/Luma/Services/FavoritesService.swift
+++ b/ios-app/Luma/Services/FavoritesService.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftUI
+
+struct NetworkFavoriteResponse: Codable {
+    let isFavorite: Bool
+}
+
+class FavoritesService {
+    private let base = URL(string: BASE_API_URL)!
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        d.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let str = try container.decode(String.self)
+            if let date = fmt.date(from: str) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date")
+        }
+        return d
+    }()
+
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    func fetchFavorites(userId: String) async throws -> [MoodRoom] {
+        let url = base.appendingPathComponent("favorites/\(userId)")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let decoded = try decoder.decode([NetworkMoodRoom].self, from: data)
+        return decoded.map { $0.toMoodRoom() }
+    }
+
+    func toggleFavorite(userId: String, moodRoomId: UUID) async throws -> Bool {
+        var request = URLRequest(url: base.appendingPathComponent("favorites"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(["userId": userId, "moodRoomId": moodRoomId.uuidString])
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let resp = try decoder.decode(NetworkFavoriteResponse.self, from: data)
+        return resp.isFavorite
+    }
+}

--- a/ios-app/Luma/Services/MoodRoomStore.swift
+++ b/ios-app/Luma/Services/MoodRoomStore.swift
@@ -6,9 +6,9 @@ class MoodRoomStore: ObservableObject {
     private let service = MoodRoomService()
     @Published var rooms: [MoodRoom] = []
 
-    func load(token: String?) async {
+    func load(token: String?, userId: String) async {
         do {
-            rooms = try await service.fetchRooms()
+            rooms = try await service.fetchRooms(userId: userId)
         } catch {
             print("Failed to load mood rooms", error)
             rooms = []
@@ -18,7 +18,7 @@ class MoodRoomStore: ObservableObject {
     func create(token: String, room: MoodRoom) async {
         do {
             _ = try await service.postRoom(token: token, room: room)
-            await load(token: token)
+            await load(token: token, userId: HARDCODED_USER_ID)
         } catch {
             print("Failed to create mood room", error)
         }


### PR DESCRIPTION
## Summary
- implement `FavoriteMoodRoom` entity and Favorites module in backend
- expose `POST /favorites` and `GET /favorites/:userId`
- extend mood rooms service to return favorite flags
- store favorite mood rooms in the iOS app and toggle via API
- add scheduled mood rooms list accessed from new menu entry

## Testing
- `npm test`
- `swiftc -parse ios-app/Luma/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_688b6bf7c8908331bb1e7cdb768371a2