### PR TITLE
Update mood room favorites handling

### DIFF
--- a/ios-app/Luma/ContentView.swift
+++ b/ios-app/Luma/ContentView.swift
@@ -57,27 +57,6 @@ struct ContentView: View {
                     .ignoresSafeArea()
 
                 ScrollView {
-                    let favRooms = moodRooms.rooms.filter { favourites.isFavorite($0) }
-                    if !favRooms.isEmpty {
-                        LazyVStack(spacing: 16) {
-                            Text("Scheduled MoodRooms")
-                                .font(.headline)
-                                .foregroundColor(.black)
-                            ForEach(favRooms) { room in
-                                if room.isJoinable {
-                                    NavigationLink(destination: MoodRoomView(room: room)) {
-                                        MoodRoomCardView(room: room)
-                                            .id(room)
-                                    }
-                                } else {
-                                    MoodRoomCardView(room: room)
-                                        .id(room)
-                                }
-                            }
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical)
-                    }
                     if events.events.isEmpty {
                         Text("No entries")
                             .foregroundColor(.secondary)

--- a/ios-app/Luma/MoodRoomCardView.swift
+++ b/ios-app/Luma/MoodRoomCardView.swift
@@ -8,6 +8,9 @@ struct MoodRoomCardView: View {
     /// Provides access to favourite state.
     @EnvironmentObject private var favourites: FavoritesStore
 
+    /// Controls display of the remove confirmation alert.
+    @State private var confirmRemove = false
+
     /// View body showing the background image and text.
     var body: some View {
         let cardWidth = UIScreen.main.bounds.width * 0.95
@@ -36,13 +39,23 @@ struct MoodRoomCardView: View {
         .overlay(alignment: .topTrailing) {
             VStack(alignment: .trailing, spacing: 2) {
                 Button(action: {
-                    Task { await favourites.toggle(room) }
+                    if favourites.isFavorite(room) {
+                        confirmRemove = true
+                    } else {
+                        Task { await favourites.toggle(room) }
+                    }
                 }) {
                     Image(systemName: favourites.isFavorite(room) ? "star.fill" : "star")
                         .resizable()
                         .frame(width: 16, height: 16)
                         .foregroundColor(favourites.isFavorite(room) ? (room.background == "MoodRoomNight" ? .white : .black) : .black)
                         .padding(6)
+                }
+                .alert("Remove this MoodRoom from your favorites?", isPresented: $confirmRemove) {
+                    Button("Yes") {
+                        Task { await favourites.toggle(room) }
+                    }
+                    Button("Cancel", role: .cancel) {}
                 }
                 if !room.isJoinable {
                     Text("Unavailable at the moment")

--- a/ios-app/Luma/ScheduledMoodRoomListView.swift
+++ b/ios-app/Luma/ScheduledMoodRoomListView.swift
@@ -14,7 +14,8 @@ struct ScheduledMoodRoomListView: View {
                     .ignoresSafeArea()
                 ScrollView {
                     LazyVStack(spacing: 16) {
-                        ForEach(favourites.rooms) { room in
+                        let rooms = favourites.rooms.sorted { $0.startTime < $1.startTime }
+                        ForEach(rooms) { room in
                             if room.isJoinable {
                                 NavigationLink(destination: MoodRoomView(room: room)) {
                                     MoodRoomCardView(room: room)


### PR DESCRIPTION
## Summary
- remove MoodRoom cards from `ContentView`
- sort `ScheduledMoodRoomListView` by start time
- add confirmation before removing favorites in `MoodRoomCardView`

## Testing
- `npm run test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_688b75760cac83319de0d8c042650d4c