### PR TITLE
Allow favoriting inactive rooms

### DIFF
--- a/ios-app/Luma/MoodRoomCardView.swift
+++ b/ios-app/Luma/MoodRoomCardView.swift
@@ -65,7 +65,6 @@ struct MoodRoomCardView: View {
                 }
             }
         }
-        .allowsHitTesting(room.isJoinable)
     }
 }
 


### PR DESCRIPTION
## Summary
- make the favourite star on `MoodRoomCardView` active regardless of room state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7bdc8630833195cf3dcdc9f0f843