### PR TITLE
Show presence count only for user moments

### DIFF
--- a/ios-app/Luma/ContentView.swift
+++ b/ios-app/Luma/ContentView.swift
@@ -197,7 +197,7 @@ struct EnergyRoomView: View {
         guard let c = count else { return "—" }
         return c == 1 ?
             "There is 1 person with you in this moment." :
-            "There are \(c) persons with you in this moment."
+            "There are \(c) people with you in this moment."
     }
 }
 

--- a/ios-app/Luma/EventDetailView.swift
+++ b/ios-app/Luma/EventDetailView.swift
@@ -60,12 +60,23 @@ struct EventDetailView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                     }
-                    Text(event.content)
-                        .font(.title)
-                        .foregroundColor(.black)
-                        .padding()
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    VStack {
+                        Spacer()
+                        Text(event.content)
+                            .font(.title)
+                            .foregroundColor(.black)
+                            .padding()
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity)
+                        Spacer()
+                        if isOwnEvent {
+                            Text(countText)
+                                .font(.footnote)
+                                .foregroundColor(.gray)
+                                .padding(.bottom, 8)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
                 .frame(width: UIScreen.main.bounds.width * 0.95,
                        height: UIScreen.main.bounds.height * 0.7)
@@ -73,7 +84,7 @@ struct EventDetailView: View {
                 .clipped()
                 .shadow(color: Color.black.opacity(0.3), radius: 10, x: 0, y: 4)
                 .padding()
-                Text(countText)
+                Text("Swipe down to leave this moment")
                     .font(.footnote)
                     .foregroundColor(.gray)
                     .padding(.bottom, 8)
@@ -82,11 +93,15 @@ struct EventDetailView: View {
         }
         .onAppear {
             stats.startMoment()
-            startPresence()
+            if isOwnEvent {
+                startPresence()
+            }
         }
         .onDisappear {
             stats.endMoment()
-            stopPresence()
+            if isOwnEvent {
+                stopPresence()
+            }
         }
     }
 
@@ -122,7 +137,7 @@ struct EventDetailView: View {
         guard let c = count else { return "—" }
         return c == 1 ?
             "There is 1 person with you in this moment." :
-            "There are \(c) persons with you in this moment."
+            "There are \(c) people with you in this moment."
     }
 }
 


### PR DESCRIPTION
## Summary
- Only display presence count for user-created moments and place it inside the card
- Always show "Swipe down to leave this moment" below the card
- Use "people" for plural presence text and skip presence updates for other moments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68978026665c8331869d12e90be8668b